### PR TITLE
Correctly process delay in apply_async

### DIFF
--- a/dispatcher/main.py
+++ b/dispatcher/main.py
@@ -119,7 +119,7 @@ class DispatcherMain:
             self.delayed_messages.remove(task)
             logger.info(f'fully processed delayed task {message}')
 
-    async def process_message(self, payload, allow_delay=True):
+    async def process_message(self, payload, allow_delay=True, broker=None):
         # TODO: handle this more elegantly, or tell clients not to do this
         if isinstance(payload, str):
             try:
@@ -145,7 +145,8 @@ class DispatcherMain:
             if 'reply_to' in message:
                 await self.pool.dispatch_task({
                     'task': 'dispatcher.brokers.pg_notify.publish_message',
-                    'args': [message['reply_to'], json.dumps(returned)]
+                    'args': [message['reply_to'], json.dumps(returned)],
+                    'kwargs': {'config': broker.config}
                 })
         else:
             await self.pool.dispatch_task(message)

--- a/dispatcher/producers/brokered.py
+++ b/dispatcher/producers/brokered.py
@@ -29,7 +29,7 @@ class BrokeredProducer:
 
         async for channel, payload in aprocess_notify(self.connection, self.channels):
             logger.info(f"Received message from channel '{channel}': {payload}")
-            await dispatcher.process_message(payload)
+            await dispatcher.process_message(payload, broker=self)
 
     async def shutdown(self):
         if self.production_task:

--- a/tools/test_methods.py
+++ b/tools/test_methods.py
@@ -1,0 +1,13 @@
+import time
+
+from dispatcher.publish import task
+
+
+@task(queue='test_channel')
+def sleep_function(seconds=1):
+    time.sleep(seconds)
+
+
+@task(queue='test_channel')
+def print_hello():
+    print('hello world!!')


### PR DESCRIPTION
This revealed that I needed some testing of `.apply_async` in the manual test script.

This creates the need for an importable module, so that's why that stuff is added here.

This opened up a few other issues, and while running it, I realized that the control-and-reply needs a Django connection to work. Well I would like it to work without a Django connection, so I pass the config to the worker. It should still use the Django connection if it has it.