### PR TITLE
Touchups to task canceling and logging

### DIFF
--- a/dispatcher/producers/scheduled.py
+++ b/dispatcher/producers/scheduled.py
@@ -21,7 +21,7 @@ class ScheduledProducer:
         logger.info(f"Starting task runner for {task_name} with interval {per_seconds} seconds")
         while True:
             await asyncio.sleep(per_seconds)
-            logger.info(f"Sending scheduled task to worker: {task_name}")
+            logger.debug(f"Produced scheduled task: {task_name}")
             await dispatcher.process_message(task_name)
 
     async def shutdown(self):

--- a/tools/write_messages.py
+++ b/tools/write_messages.py
@@ -40,16 +40,19 @@ async def main():
     print('writing 15 messages fast')
     for i in range(15):
         publish_message('test_channel', f'lambda: {i}', config={'conninfo': CONNECTION_STRING})
+
     print('')
-    print('writing a control message')
-
+    print('performing a task cancel')
     # submit a task we will "find" two different ways
-    publish_message(channel, json.dumps({'task': 'lambda: 4', 'uuid': 'foobar'}), config={'conninfo': CONNECTION_STRING})
-
+    publish_message(channel, json.dumps({'task': 'lambda: __import__("time").sleep(3.1415)', 'uuid': 'foobar'}), config={'conninfo': CONNECTION_STRING})
     ctl = Control('test_channel', config={'conninfo': CONNECTION_STRING})
-    # running_data = ctl.control_with_reply('running', data={'task': 'lambda: 4'})
-    # print(json.dumps(running_data, indent=2))
-    running_data = ctl.control_with_reply('cancel', data={'uuid': 'foobar'})
+    canceled_jobs = ctl.control_with_reply('cancel', data={'uuid': 'foobar'})
+    print(json.dumps(canceled_jobs, indent=2))
+
+    print('')
+    print('finding a running task by its task name')
+    publish_message(channel, json.dumps({'task': 'lambda: __import__("time").sleep(3.1415)', 'uuid': 'foobar2'}), config={'conninfo': CONNECTION_STRING})
+    running_data = ctl.control_with_reply('running', data={'task': 'lambda: __import__("time").sleep(3.1415)'})
     print(json.dumps(running_data, indent=2))
 
     print('writing a message with a delay')


### PR DESCRIPTION
The happy-path cancel wasn't working as intended, because it seems the python default SIGTERM is actually more aggressive than I would have liked. The worker doesn't give any status updates as it quits.

This implements what I thought would have been the assumption - that a SIGTERM cancels the current task, and the worker will wait for instructions from its manager about what to do next. Once we get back to the queue read, we should be in our normal happy state, and if we have to SIGKILL it later, that's in the normal shutdown logic paths.

And I had other logging reduction changes pending that I incorporated into this. Tried to use the task uuid more consistently... etc...