### PR TITLE
Speed up control commands with async implementation

### DIFF
--- a/dispatcher/brokers/pg_notify.py
+++ b/dispatcher/brokers/pg_notify.py
@@ -48,6 +48,14 @@ async def aprocess_notify(connection, channels):
                 yield notify.channel, notify.payload
 
 
+async def apublish_message(connection, channel, payload=None):
+    async with connection.cursor() as cur:
+        if not payload:
+            await cur.execute(f'NOTIFY {channel};')
+        else:
+            await cur.execute(f"NOTIFY {channel}, '{payload}';")
+
+
 def get_django_connection():
     try:
         from django.conf import ImproperlyConfigured

--- a/dispatcher/producers/brokered.py
+++ b/dispatcher/producers/brokered.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 
-from dispatcher.brokers.pg_notify import aget_connection, aprocess_notify
+from dispatcher.brokers.pg_notify import aget_connection, aprocess_notify, apublish_message
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +15,8 @@ class BrokeredProducer:
         self.connection = None
 
     async def start_producing(self, dispatcher):
+        await self.connect()
+
         self.production_task = asyncio.create_task(self.produce_forever(dispatcher))
         # TODO: implement connection retry logic
         self.production_task.add_done_callback(dispatcher.fatal_error_callback)
@@ -28,11 +30,12 @@ class BrokeredProducer:
         self.connection = await aget_connection(self.config)
 
     async def produce_forever(self, dispatcher):
-        await self.connect()
-
         async for channel, payload in aprocess_notify(self.connection, self.channels):
             logger.info(f"Received message from channel '{channel}': {payload}")
             await dispatcher.process_message(payload, broker=self)
+
+    async def notify(self, channel, payload=None):
+        await apublish_message(self.connection, channel, payload=payload)
 
     async def shutdown(self):
         if self.production_task:

--- a/dispatcher/publish.py
+++ b/dispatcher/publish.py
@@ -100,6 +100,7 @@ class task:
                     queue = queue()
                 # TODO: before sending, consult an app-specific callback if configured
                 from dispatcher.brokers.pg_notify import publish_message
+
                 # NOTE: the kw will communicate things in the database connection data
                 publish_message(queue, json.dumps(obj), config=config, **kw)
                 return (obj, queue)

--- a/tools/write_messages.py
+++ b/tools/write_messages.py
@@ -1,9 +1,8 @@
 # send_notifications.py
 import json
+import logging
 import os
 import sys
-
-import asyncio
 
 from dispatcher.brokers.pg_notify import publish_message
 from dispatcher.control import Control
@@ -15,8 +14,7 @@ tools_dir = os.path.abspath(
 
 sys.path.append(tools_dir)
 
-from test_methods import sleep_function, print_hello
-
+from test_methods import print_hello, sleep_function
 
 # Database connection details
 CONNECTION_STRING = "dbname=dispatch_db user=dispatch password=dispatching host=localhost port=55777"
@@ -29,7 +27,7 @@ TEST_MSGS = [
 ]
 
 
-async def main():
+def main():
     print('writing some basic test messages')
     for channel, message in TEST_MSGS:
         # Send the notification
@@ -74,9 +72,8 @@ async def main():
     print(json.dumps(running_data, indent=2))
 
     print('')
-    print('cancel a delayed tasks')
-    running_data = ctl.control_with_reply('cancel', data={'task': 'test_methods.sleep_function'})
-    print(json.dumps(running_data, indent=2))
+    print('cancel a delayed task with no reply for demonstration')
+    ctl.control('cancel', data={'task': 'test_methods.sleep_function'})  # NOTE: no reply
     print('confirmation that it has been canceled')
     running_data = ctl.control_with_reply('running', data={'task': 'test_methods.sleep_function'})
     print(json.dumps(running_data, indent=2))
@@ -89,4 +86,5 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    logging.basicConfig(level='ERROR', stream=sys.stdout)
+    main()


### PR DESCRIPTION
Previously, every time this used it was mandated that it would run for slightly over 1 second. This obviously isn't workable long-term, but probably fine for now.

Turned out, that created race conditions because of the delay it introduced. Now, this can't possibly be solely the fault of control-and-reply, and yes, other problems were discovered and fixed regarding the task dispatching & locking mechanic.

That still motivated me to get a solution for this, and as of this minute, it tends to run `0.08` seconds for a control-and-reply... which is still a bit much. But we're starting from the assumption of synchronous code, so we have to create an event loop, and create a new connection. The act of creating the connection is probably driving that time.