### PR TITLE
Start pattern to disallow untyped functions, MyPY updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - run: pip install mypy
       - run: pip install -e .[pg_notify]
       - run: python3 -m pip install types-PyYAML
-      - run: mypy --ignore-missing-imports dispatcher
+      - run: mypy dispatcher
 
   flake8:
     name: Run flake8

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ linters:
 	black dispatcher/
 	isort dispatcher/
 	flake8 dispatcher/
-	mypy --ignore-missing-imports dispatcher
+	mypy dispatcher

--- a/dispatcher/protocols.py
+++ b/dispatcher/protocols.py
@@ -65,7 +65,6 @@ class WorkerPool(Protocol):
 
 
 class DispatcherMain(Protocol):
-    fd_lock: asyncio.Lock
 
     async def main(self) -> None:
         """This is the method that runs the service, bring your own event loop"""

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+
+[mypy-dispatcher.control]
+disallow_untyped_defs = True


### PR DESCRIPTION
Coming from feedback in https://github.com/ansible/dispatcher/pull/88 and others, this starts to make sense.

I don't think this is a good idea for every library, and it may not be a good idea for all modules within the dispatcher. But the dispatcher is specialized as a code contract for other apps. The `dispatcher/control.py` module is a good example, as it originally came from AWX where we did none of this, but it is externally-facing, and this enables some meaningful progress towards integration in other apps. Speaking more specifically, there is value in the communication that `.control_with_reply` returns a list of dictionaries. This should be elaborated further to clarify that each dictionary in the list is data returned from a dispatcher service, since multiple running dispatcher services may reply.

Option `--ignore-missing-imports` was probably no longer needed after removing Django imports. This was possible after we clearly defined the swim lanes for dispatcher versus DAB.