### PR TITLE
Split logic for task blocking and queuing into a new module

### DIFF
--- a/dispatcher/control.py
+++ b/dispatcher/control.py
@@ -80,7 +80,7 @@ class Control(object):
         await producer.start_producing(control_callbacks)
         for task in producer.all_tasks():
             # Make sure we catch errors
-            ensure_fatal(task)
+            ensure_fatal(task, exit_event=control_callbacks.events.exit_event)
 
         await producer.events.ready_event.wait()
 

--- a/dispatcher/producers/on_start.py
+++ b/dispatcher/producers/on_start.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 from typing import Union
 
+from ..protocols import DispatcherMain
 from .base import BaseProducer
 
 logger = logging.getLogger(__name__)
@@ -12,7 +13,7 @@ class OnStartProducer(BaseProducer):
         self.task_list = task_list
         super().__init__()
 
-    async def start_producing(self, dispatcher) -> None:
+    async def start_producing(self, dispatcher: DispatcherMain) -> None:
         self.events.ready_event.set()
 
         for task_name, options in self.task_list.items():

--- a/dispatcher/producers/scheduled.py
+++ b/dispatcher/producers/scheduled.py
@@ -28,7 +28,7 @@ class ScheduledProducer(BaseProducer):
         self.task_schedule = task_schedule
         self.schedule_entries: set[ScheduleEntry] = set()
         self.dispatcher: Optional[DispatcherMain] = None
-        self.schedule_runner = NextWakeupRunner(self.schedule_entries, self.trigger_schedule)
+        self.schedule_runner = NextWakeupRunner(self.schedule_entries, self.trigger_schedule, name='ScheduledProducer')
         super().__init__()
 
     async def trigger_schedule(self, entry: ScheduleEntry) -> None:
@@ -41,6 +41,7 @@ class ScheduledProducer(BaseProducer):
 
     async def start_producing(self, dispatcher: DispatcherMain, exit_event: Optional[asyncio.Event] = None) -> None:
         self.dispatcher = dispatcher
+        self.schedule_runner.exit_event = exit_event
         current_time = time.monotonic()
 
         for task_name, options in self.task_schedule.items():

--- a/dispatcher/producers/scheduled.py
+++ b/dispatcher/producers/scheduled.py
@@ -39,7 +39,7 @@ class ScheduledProducer(BaseProducer):
         if self.dispatcher:
             await self.dispatcher.process_message(message)
 
-    async def start_producing(self, dispatcher: DispatcherMain) -> None:
+    async def start_producing(self, dispatcher: DispatcherMain, exit_event: Optional[asyncio.Event] = None) -> None:
         self.dispatcher = dispatcher
         current_time = time.monotonic()
 

--- a/dispatcher/protocols.py
+++ b/dispatcher/protocols.py
@@ -55,7 +55,7 @@ class Producer(Protocol):
 
 
 class WorkerPool(Protocol):
-    async def start_working(self, forking_lock: asyncio.Lock) -> None:
+    async def start_working(self, forking_lock: asyncio.Lock, exit_event: Optional[asyncio.Event] = None) -> None:
         """Start persistent asyncio tasks, including asychronously starting worker subprocesses"""
         ...
 

--- a/dispatcher/service/asyncio_tasks.py
+++ b/dispatcher/service/asyncio_tasks.py
@@ -1,21 +1,36 @@
 import asyncio
 import logging
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 
-def done_callback(task: asyncio.Task) -> None:
-    try:
-        task.result()
-    except asyncio.CancelledError:
-        logger.info(f'Ack that task {task.get_name()} was canceled')
+class CallbackHolder:
+    def __init__(self, exit_event: Optional[asyncio.Event]):
+        self.exit_event = exit_event
+
+    def done_callback(self, task: asyncio.Task) -> None:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            logger.info(f'Ack that task {task.get_name()} was canceled')
+        except Exception:
+            if self.exit_event:
+                self.exit_event.set()
+            raise
 
 
-def ensure_fatal(task: asyncio.Task) -> asyncio.Task:
-    task.add_done_callback(done_callback)
+def ensure_fatal(task: asyncio.Task, exit_event: Optional[asyncio.Event] = None) -> asyncio.Task:
+    holder = CallbackHolder(exit_event)
+    task.add_done_callback(holder.done_callback)
 
     # address race condition if attached to task right away
     if task.done():
-        task.result()
+        try:
+            task.result()
+        except Exception:
+            if exit_event:
+                exit_event.set()
+            raise
 
     return task  # nicety so this can be used as a wrapper

--- a/dispatcher/service/blocker.py
+++ b/dispatcher/service/blocker.py
@@ -1,0 +1,89 @@
+import logging
+from typing import Optional
+
+from ..utils import DuplicateBehavior
+from .queuer import Queuer
+
+logger = logging.getLogger(__name__)
+
+
+class Blocker:
+    def __init__(self, queuer: Queuer) -> None:
+        self.blocked_messages: list[dict] = []  # TODO: use deque, customizability
+        self.queuer = queuer
+        self.discard_count: int = 0
+        self.shutting_down: bool = False
+
+    def _duplicate_in_list(self, message, task_iter) -> bool:
+        for other_message in task_iter:
+            if other_message is message:
+                continue
+            keys = ('task', 'args', 'kwargs')
+            if all(other_message.get(key) == message.get(key) for key in keys):
+                return True
+        return False
+
+    def already_running(self, message) -> bool:
+        return self._duplicate_in_list(message, self.queuer.running_tasks())
+
+    def already_queued(self, message) -> bool:
+        return self._duplicate_in_list(message, self.blocked_messages)
+
+    def process_task(self, message: dict) -> Optional[dict]:
+        """If task is blocked, it is consumed here and None is returned, if not blocked, return message as-is
+
+        Consuming the message may mean discarding it, or it may mean holding it until it is unblocked.
+        If task if not blocked and is returned, that means you should continue doing what you were going to do.
+        """
+        uuid = message.get("uuid", "<unknown>")
+        on_duplicate = message.get('on_duplicate', DuplicateBehavior.parallel.value)
+
+        if self.shutting_down:
+            logger.info(f'Not starting task (uuid={uuid}) because we are shutting down, queued_ct={len(self.blocked_messages)}')
+            self.blocked_messages.append(message)
+            return None
+
+        if on_duplicate == DuplicateBehavior.serial.value:
+            if self.already_running(message):
+                logger.info(f'Queuing task (uuid={uuid}) because it is already running, queued_ct={len(self.blocked_messages)}')
+                self.blocked_messages.append(message)
+                return None
+
+        elif on_duplicate == DuplicateBehavior.discard.value:
+            if self.already_running(message) or self.already_queued(message):
+                logger.info(f'Discarding task because it is already running: \n{message}')
+                self.discard_count += 1
+                return None
+
+        elif on_duplicate == DuplicateBehavior.queue_one.value:
+            if self.already_queued(message):
+                logger.info(f'Discarding task because it is already running and queued: \n{message}')
+                self.discard_count += 1
+                return None
+            elif self.already_running(message):
+                logger.info(f'Queuing task (uuid={uuid}) because it is already running, queued_ct={len(self.blocked_messages)}')
+                self.blocked_messages.append(message)
+                return None
+
+        elif on_duplicate != DuplicateBehavior.parallel.value:
+            logger.warning(f'Got unexpected on_duplicate value {on_duplicate} in message {message}')
+
+        return message
+
+    def pop_unblocked_messages(self) -> list[dict]:
+        now_unblocked = []
+        for message in self.blocked_messages.copy():
+            # All forms of blocking require task to not be running or queued in order to release
+            if not (self.already_running(message) or self.already_queued(message)):
+                now_unblocked.append(message)
+                self.blocked_messages.remove(message)
+        return now_unblocked
+
+    def count(self) -> int:
+        return len(self.blocked_messages)
+
+    def shutdown(self) -> None:
+        self.shutting_down = True
+        if self.blocked_messages:
+            uuids = [message.get('uuid', '<unknown>') for message in self.blocked_messages]
+            logger.error(f'Dispatcher shut down with blocked work, uuids: {uuids}')

--- a/dispatcher/service/main.py
+++ b/dispatcher/service/main.py
@@ -40,7 +40,6 @@ class DelayCapsule(HasWakeup):
 class DispatcherMain:
     def __init__(self, producers: Iterable[Producer], pool: WorkerPool, node_id: Optional[str] = None):
         self.delayed_messages: set[DelayCapsule] = set()
-        self.delayed_runner = NextWakeupRunner(self.delayed_messages, self.process_delayed_task)
         self.received_count = 0
         self.control_count = 0
         self.shutting_down = False
@@ -60,6 +59,9 @@ class DispatcherMain:
             self.node_id = str(uuid4())
 
         self.events: DispatcherEvents = DispatcherEvents()
+
+        self.delayed_runner = NextWakeupRunner(self.delayed_messages, self.process_delayed_task, name='delayed_task_runner')
+        self.delayed_runner.exit_event = self.events.exit_event
 
     def receive_signal(self, *args, **kwargs) -> None:
         logger.warning(f"Received exit signal args={args} kwargs={kwargs}")

--- a/dispatcher/service/main.py
+++ b/dispatcher/service/main.py
@@ -194,7 +194,7 @@ class DispatcherMain:
     async def start_working(self) -> None:
         logger.debug('Filling the worker pool')
         try:
-            await self.pool.start_working(self.fd_lock)
+            await self.pool.start_working(self.fd_lock, exit_event=self.events.exit_event)
         except Exception:
             logger.exception(f'Pool {self.pool} failed to start working')
             self.events.exit_event.set()
@@ -211,7 +211,7 @@ class DispatcherMain:
                 # TODO: recycle producer instead of raising up error
                 # https://github.com/ansible/dispatcherd/issues/2
                 for task in producer.all_tasks():
-                    ensure_fatal(task)
+                    ensure_fatal(task, exit_event=self.events.exit_event)
 
     async def cancel_tasks(self):
         for task in asyncio.all_tasks():

--- a/dispatcher/service/next_wakeup_runner.py
+++ b/dispatcher/service/next_wakeup_runner.py
@@ -41,6 +41,8 @@ class NextWakeupRunner:
         self.asyncio_task: Optional[asyncio.Task] = None
         self.kick_event = asyncio.Event()
         self.shutting_down: bool = False
+        # If we hit errors, will set this to tell main program to exit, not expected to be present at __init__
+        self.exit_event: Optional[asyncio.Event] = None
         if name is None:
             method_name = getattr(process_object, '__name__', str(process_object))
             self.name = f'next-run-manager-of-{method_name}'
@@ -95,7 +97,7 @@ class NextWakeupRunner:
     def mk_new_task(self) -> None:
         """Should only be called if a task is not currently running"""
         self.asyncio_task = asyncio.create_task(self.background_task(), name=self.name)
-        ensure_fatal(self.asyncio_task)
+        ensure_fatal(self.asyncio_task, exit_event=self.exit_event)
 
     async def kick(self) -> None:
         """Initiates the asyncio task to wake up at the next run time

--- a/dispatcher/service/pool.py
+++ b/dispatcher/service/pool.py
@@ -217,6 +217,7 @@ class WorkerPool:
     async def start_working(self, forking_lock: asyncio.Lock, exit_event: Optional[asyncio.Event] = None) -> None:
         self.read_results_task = ensure_fatal(asyncio.create_task(self.read_results_forever(), name='results_task'), exit_event=exit_event)
         self.management_task = ensure_fatal(asyncio.create_task(self.manage_workers(forking_lock=forking_lock), name='management_task'), exit_event=exit_event)
+        self.timeout_runner.exit_event = exit_event
 
     def get_running_count(self) -> int:
         ct = 0

--- a/dispatcher/service/pool.py
+++ b/dispatcher/service/pool.py
@@ -6,8 +6,8 @@ import time
 from typing import Any, Literal, Optional
 
 from .asyncio_tasks import ensure_fatal
-from .next_wakeup_runner import HasWakeup, NextWakeupRunner
 from .blocker import Blocker
+from .next_wakeup_runner import HasWakeup, NextWakeupRunner
 from .process import ProcessManager, ProcessProxy
 from .queuer import Queuer
 

--- a/dispatcher/service/pool.py
+++ b/dispatcher/service/pool.py
@@ -3,12 +3,13 @@ import logging
 import os
 import signal
 import time
-from typing import Any, Iterator, Literal, Optional
+from typing import Any, Literal, Optional
 
-from ..utils import DuplicateBehavior, MessageAction
 from .asyncio_tasks import ensure_fatal
 from .next_wakeup_runner import HasWakeup, NextWakeupRunner
+from .blocker import Blocker
 from .process import ProcessManager, ProcessProxy
+from .queuer import Queuer
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,10 @@ class PoolWorker(HasWakeup):
         self.finished_count = 0
         self.status: Literal['initialized', 'spawned', 'starting', 'ready', 'stopping', 'exited', 'error', 'retired'] = 'initialized'
         self.exit_msg_event = asyncio.Event()
+
+    def is_ready(self):
+        """Worker is ready to receive task requests"""
+        return bool(self.status == 'ready')
 
     async def start(self) -> None:
         if self.status != 'initialized':
@@ -174,12 +179,10 @@ class WorkerPool:
 
         # internal tracking variables
         self.workers: dict[int, PoolWorker] = {}
-        self.queued_messages: list[dict] = []  # TODO: use deque https://github.com/ansible/dispatcherd/issues/104
         self.next_worker_id = 0
         self.shutting_down = False
         self.finished_count: int = 0
         self.canceled_count: int = 0
-        self.discard_count: int = 0
         self.shutdown_timeout = 3
 
         # the timeout runner keeps its own task
@@ -199,17 +202,21 @@ class WorkerPool:
         self.worker_stop_wait = worker_stop_wait  # seconds to wait for a worker to exit on its own before SIGTERM, SIGKILL
         self.worker_removal_wait = worker_removal_wait  # after worker process exits, seconds to keep its record, for stats
 
+        # queuer and blocker objects hold an internal inventory of tasks that can not yet run
+        self.queuer = Queuer(self.workers.values())
+        self.blocker = Blocker(self.queuer)
+
     @property
     def processed_count(self):
-        return self.finished_count + self.canceled_count + self.discard_count
+        return self.finished_count + self.canceled_count + self.blocker.discard_count
 
     @property
     def received_count(self):
-        return self.processed_count + len(self.queued_messages) + sum(1 for w in self.workers.values() if w.current_task)
+        return self.processed_count + self.queuer.count() + self.blocker.count() + sum(1 for w in self.workers.values() if w.current_task)
 
-    async def start_working(self, forking_lock: asyncio.Lock) -> None:
-        self.read_results_task = ensure_fatal(asyncio.create_task(self.read_results_forever(), name='results_task'))
-        self.management_task = ensure_fatal(asyncio.create_task(self.manage_workers(forking_lock=forking_lock), name='management_task'))
+    async def start_working(self, forking_lock: asyncio.Lock, exit_event: Optional[asyncio.Event] = None) -> None:
+        self.read_results_task = ensure_fatal(asyncio.create_task(self.read_results_forever(), name='results_task'), exit_event=exit_event)
+        self.management_task = ensure_fatal(asyncio.create_task(self.manage_workers(forking_lock=forking_lock), name='management_task'), exit_event=exit_event)
 
     def get_running_count(self) -> int:
         ct = 0
@@ -368,6 +375,8 @@ class WorkerPool:
         self.shutting_down = True
         self.events.management_event.set()
         await self.timeout_runner.shutdown()
+        self.queuer.shutdown()
+        self.blocker.shutdown()
         await self.stop_workers()
         self.process_manager.finished_queue.put('stop')
 
@@ -391,125 +400,45 @@ class WorkerPool:
             except asyncio.CancelledError:
                 pass  # intended
 
-        if self.queued_messages:
-            uuids = [message.get('uuid', '<unknown>') for message in self.queued_messages]
-            logger.error(f'Dispatcher shut down with queued work, uuids: {uuids}')
-
         logger.info('Pool is shut down')
-
-    def get_free_worker(self) -> Optional[PoolWorker]:
-        for candidate_worker in self.workers.values():
-            if (not candidate_worker.current_task) and candidate_worker.status == 'ready':
-                return candidate_worker
-        return None
-
-    def running_tasks(self) -> Iterator[dict]:
-        for worker in self.workers.values():
-            if worker.current_task:
-                yield worker.current_task
-
-    def _duplicate_in_list(self, message, task_iter) -> bool:
-        for other_message in task_iter:
-            if other_message is message:
-                continue
-            keys = ('task', 'args', 'kwargs')
-            if all(other_message.get(key) == message.get(key) for key in keys):
-                return True
-        return False
-
-    def already_running(self, message) -> bool:
-        return self._duplicate_in_list(message, self.running_tasks())
-
-    def already_queued(self, message) -> bool:
-        return self._duplicate_in_list(message, self.queued_messages)
-
-    def get_blocking_action(self, message: dict) -> str:
-        on_duplicate = message.get('on_duplicate', DuplicateBehavior.parallel.value)
-
-        if on_duplicate == DuplicateBehavior.serial.value:
-            if self.already_running(message):
-                return MessageAction.queue.value
-
-        elif on_duplicate == DuplicateBehavior.discard.value:
-            if self.already_running(message) or self.already_queued(message):
-                return MessageAction.discard.value
-
-        elif on_duplicate == DuplicateBehavior.queue_one.value:
-            if self.already_queued(message):
-                return MessageAction.discard.value
-            elif self.already_running(message):
-                return MessageAction.queue.value
-
-        elif on_duplicate != DuplicateBehavior.parallel.value:
-            logger.warning(f'Got unexpected on_duplicate value {on_duplicate}')
-
-        return MessageAction.run.value
-
-    def message_is_blocked(self, message: dict) -> bool:
-        return bool(self.get_blocking_action(message) == MessageAction.queue.value)
-
-    def get_unblocked_message(self) -> Optional[dict]:
-        """Returns a message from the queue that is unblocked to run, if one exists"""
-        for message in self.queued_messages:
-            if not self.message_is_blocked(message):
-                return message
-        return None
-
-    def unblocked_message_ct(self) -> int:
-        "The number of queued tasks currently eligible to run"
-        unblocked_msg_ct = 0
-        for message in self.queued_messages:
-            if not self.message_is_blocked(message):
-                unblocked_msg_ct += 1
-        return unblocked_msg_ct
 
     def active_task_ct(self) -> int:
         "The number of tasks currently being ran, or immediently eligible to run"
-        return self.get_running_count() + self.unblocked_message_ct()
+        return self.get_running_count() + self.queuer.count()
 
-    async def post_task_start(self, message):
+    async def post_task_start(self, message: dict) -> None:
         if 'timeout' in message:
             await self.timeout_runner.kick()  # kick timeout task to set wakeup
         running_ct = self.get_running_count()
         self.last_used_by_ct[running_ct] = None  # block scale down of this amount
 
     async def dispatch_task(self, message: dict) -> None:
+        uuid = message.get("uuid", "<unknown>")
         async with self.management_lock:
-            uuid = message.get("uuid", "<unknown>")
-
-            blocking_action = self.get_blocking_action(message)
-            if blocking_action == MessageAction.discard.value:
-                logger.info(f'Discarding task because it is already running: \n{message}')
-                self.discard_count += 1
-                return
-            elif self.shutting_down:
-                logger.info(f'Not starting task (uuid={uuid}) because we are shutting down, queued_ct={len(self.queued_messages)}')
-                self.queued_messages.append(message)
-                return
-            elif blocking_action == MessageAction.queue.value:
-                logger.info(f'Queuing task (uuid={uuid}) because it is already running or queued, queued_ct={len(self.queued_messages)}')
-                self.queued_messages.append(message)
-                return
-
-            if worker := self.get_free_worker():
-                logger.debug(f"Dispatching task (uuid={uuid}) to worker (id={worker.worker_id})")
-                await worker.start_task(message)
-                await self.post_task_start(message)
-            else:
-                logger.warning(f'Queueing task (uuid={uuid}), ran out of workers, queued_ct={len(self.queued_messages)}')
-                self.queued_messages.append(message)
-                self.events.management_event.set()  # kick manager task to start auto-scale up
+            if unblocked_task := self.blocker.process_task(message):
+                if worker := self.queuer.get_worker_or_process_task(unblocked_task):
+                    logger.debug(f"Dispatching task (uuid={uuid}) to worker (id={worker.worker_id})")
+                    await worker.start_task(unblocked_task)
+                    await self.post_task_start(unblocked_task)
+                else:
+                    self.events.management_event.set()  # kick manager task to start auto-scale up
 
     async def drain_queue(self) -> None:
-        work_done = False
-        while requeue_message := self.get_unblocked_message():
-            if (not self.get_free_worker()) or self.shutting_down:
-                return
-            self.queued_messages.remove(requeue_message)
-            await self.dispatch_task(requeue_message)
-            work_done = True
+        async with self.management_lock:
+            # First move all unblocked tasks into the blocked-on-capacity queue
+            for message in self.blocker.pop_unblocked_messages():
+                self.queuer.queued_messages.append(message)
 
-        if work_done:
+        # Now process all messages we can in the unblocked queue
+        processed_queue = False
+        for message in self.queuer.queued_messages.copy():
+            if (not self.queuer.get_free_worker()) or self.shutting_down:
+                return
+            self.queuer.queued_messages.remove(message)
+            await self.dispatch_task(message)
+            processed_queue = True
+
+        if processed_queue:
             self.events.queue_cleared.set()
 
     async def process_finished(self, worker, message) -> None:
@@ -537,7 +466,7 @@ class WorkerPool:
                 self.finished_count += 1
             worker.mark_finished_task()
 
-        if not self.queued_messages and all(worker.current_task is None for worker in self.workers.values()):
+        if not self.queuer.queued_messages and all(worker.current_task is None for worker in self.workers.values()):
             self.events.work_cleared.set()
 
         if 'timeout' in message:

--- a/dispatcher/service/queuer.py
+++ b/dispatcher/service/queuer.py
@@ -1,0 +1,53 @@
+import logging
+from typing import Iterable, Iterator, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class PoolWorkerProto(Protocol):
+    current_task: Optional[dict]
+    worker_id: int
+
+    async def start_task(self, message: dict) -> None: ...
+
+    def is_ready(self) -> bool: ...
+
+
+class Queuer:
+    def __init__(self, workers: Iterable[PoolWorkerProto]) -> None:
+        self.queued_messages: list[dict] = []  # TODO: use deque, customizability
+        self.workers = workers
+
+    def count(self) -> int:
+        return len(self.queued_messages)
+
+    def get_free_worker(self) -> Optional[PoolWorkerProto]:
+        for candidate_worker in self.workers:
+            if (not candidate_worker.current_task) and candidate_worker.is_ready():
+                return candidate_worker
+        return None
+
+    def running_tasks(self) -> Iterator[dict]:
+        for worker in self.workers:
+            if worker.current_task:
+                yield worker.current_task
+
+    def get_worker_or_process_task(self, message) -> Optional[PoolWorkerProto]:
+        """Either give a worker to place the task on, or put message into queue
+
+        In the future we may change to optionally discard some tasks.
+        """
+        uuid = message.get("uuid", "<unknown>")
+        if worker := self.get_free_worker():
+            logger.debug(f"Dispatching task (uuid={uuid}) to worker (id={worker.worker_id})")
+            return worker
+        else:
+            logger.warning(f'Queueing task (uuid={uuid}), due to lack of capacity, queued_ct={len(self.queued_messages)}')
+            self.queued_messages.append(message)
+            return None
+
+    def shutdown(self) -> None:
+        """Just write log messages about what backed up work we will lose"""
+        if self.queued_messages:
+            uuids = [message.get('uuid', '<unknown>') for message in self.queued_messages]
+            logger.error(f'Dispatcher shut down with queued work, uuids: {uuids}')

--- a/dispatcher/utils.py
+++ b/dispatcher/utils.py
@@ -45,12 +45,6 @@ def serialize_task(f: Callable) -> str:
     return MODULE_METHOD_DELIMITER.join([f.__module__, f.__name__])
 
 
-class MessageAction(Enum):
-    run = 'run'
-    discard = 'discard'
-    queue = 'queue'
-
-
 class DuplicateBehavior(Enum):
     parallel = 'parallel'  # run multiple versions of same task at same time
     discard = 'discard'  # if task is submitted twice, discard the 2nd one

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -200,7 +200,7 @@ async def test_task_discard(apg_dispatcher, pg_message):
     await wait_to_receive(apg_dispatcher, 10)
 
     pool = apg_dispatcher.pool
-    assert [pool.finished_count, pool.discard_count] == [0, 9]  # First task should still be running
+    assert [pool.finished_count, pool.blocker.discard_count] == [0, 9]  # First task should still be running
 
 
 @pytest.mark.asyncio
@@ -211,7 +211,7 @@ async def test_task_discard_in_task_definition(apg_dispatcher, test_settings):
     await wait_to_receive(apg_dispatcher, 10)
 
     pool = apg_dispatcher.pool
-    assert [pool.finished_count, pool.discard_count] == [0, 9]  # First task should still be running
+    assert [pool.finished_count, pool.blocker.discard_count] == [0, 9]  # First task should still be running
 
 
 @pytest.mark.asyncio
@@ -222,7 +222,7 @@ async def test_tasks_in_serial(apg_dispatcher, test_settings):
     await wait_to_receive(apg_dispatcher, 10)
 
     pool = apg_dispatcher.pool
-    assert [pool.finished_count, sum(1 for w in pool.workers.values() if w.current_task), len(pool.queued_messages), pool.discard_count] == [0, 1, 9, 0]
+    assert [pool.finished_count, sum(1 for w in pool.workers.values() if w.current_task), pool.blocker.count(), pool.blocker.discard_count] == [0, 1, 9, 0]
 
 
 @pytest.mark.asyncio
@@ -233,7 +233,7 @@ async def test_tasks_queue_one(apg_dispatcher, test_settings):
     await wait_to_receive(apg_dispatcher, 10)
 
     pool = apg_dispatcher.pool
-    assert [pool.finished_count, sum(1 for w in pool.workers.values() if w.current_task), len(pool.queued_messages), pool.discard_count] == [0, 1, 1, 8]
+    assert [pool.finished_count, sum(1 for w in pool.workers.values() if w.current_task), pool.blocker.count(), pool.blocker.discard_count] == [0, 1, 1, 8]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/service/producers/test_scheduled_producer.py
+++ b/tests/unit/service/producers/test_scheduled_producer.py
@@ -15,9 +15,6 @@ class Dispatcher:
         assert 'schedule' not in message
         raise ItWorked
 
-    def fatal_error_callback(self, *args, **kwargs):
-        raise Exception('task error')
-
 
 async def run_schedules_for_a_while(producer):
     dispatcher = Dispatcher()

--- a/tests/unit/service/test_asyncio_tasks.py
+++ b/tests/unit/service/test_asyncio_tasks.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 
 import pytest
 
@@ -12,10 +11,13 @@ async def will_fail():
 
 @pytest.mark.asyncio
 async def test_capture_initial_task_failure():
+    event = asyncio.Event()
+    assert not event.is_set()
     aio_task = asyncio.create_task(will_fail())
     with pytest.raises(RuntimeError):
-        ensure_fatal(aio_task)
+        ensure_fatal(aio_task, exit_event=event)
         await aio_task
+    assert event.is_set()
 
 
 async def will_fail_soon():
@@ -25,10 +27,13 @@ async def will_fail_soon():
 
 @pytest.mark.asyncio
 async def test_capture_later_task_failure():
+    event = asyncio.Event()
+    assert not event.is_set()
     aio_task = asyncio.create_task(will_fail_soon())
     with pytest.raises(RuntimeError):
-        ensure_fatal(aio_task)
+        ensure_fatal(aio_task, exit_event=event)
         await aio_task
+    assert event.is_set()
 
 
 async def good_task():
@@ -37,6 +42,9 @@ async def good_task():
 
 @pytest.mark.asyncio
 async def test_task_does_not_fail_so_okay():
+    event = asyncio.Event()
+    assert not event.is_set()
     aio_task = asyncio.create_task(good_task())
-    ensure_fatal(aio_task)
+    ensure_fatal(aio_task, exit_event=event)
     await aio_task
+    assert not event.is_set()


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcherd/issues/85

This handles 2 of the classes mentioned there, becoming "processors" which is a new basic type of thing, here.

The 3rd type of the delayer will have its work... well... delayed, because https://github.com/ansible/dispatcherd/pull/108 will be heavily conflicting. That will become both a "processor" and a "next-wakup-runner-thing".

As such, I'm happy with this in terms of the code now. Yes, we could do _better_, and perhaps this was put together a little hastily at first. But this is an improvement and there is an outline of where we're going with it.

There are some performance aspects that could be better, but again, I don't think worse than before. I wanted to address that, but it needs a new class to replace passing around the `message` dictionary, and that's just too much right now.

----

But big picture your question is probably why we would be doing any of this? Because of https://github.com/ansible/dispatcherd/issues/63

This, along with auto-scaling, are the 2 pieces of groundwork to allow adding these capacity-management options to tasks. Yes, I already went ahead and added some new task options, but those are related to _blocking_ which can result in discarding, which is something to help with capacity management. Specifically the ability to have some tasks (but not others) avoid consuming a count of "reserve" workers is very important. This will allow the service to _virtually always_ maintain instantaneous worker capacity for more important work.