### PR TITLE
Use SIGUSR1 for task cancellation (w/ tests)

### DIFF
--- a/dispatcher/service/pool.py
+++ b/dispatcher/service/pool.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+import os
+import signal
 import time
 from asyncio import Task
 from typing import Any, Iterator, Optional
@@ -70,7 +72,8 @@ class PoolWorker:
 
     def cancel(self) -> None:
         self.is_active_cancel = True  # signal for result callback
-        self.process.terminate()  # SIGTERM
+        # Use SIGUSR1 instead of SIGTERM to avoid conflicts with task signal handlers
+        os.kill(self.process.pid, signal.SIGUSR1)
 
     def get_data(self) -> dict[str, Any]:
         return {

--- a/dispatcher/worker/task.py
+++ b/dispatcher/worker/task.py
@@ -26,7 +26,9 @@ class WorkerSignalHandler:
     def __init__(self, worker_id):
         self.kill_now = False
         self.worker_id = worker_id
-        signal.signal(signal.SIGTERM, self.task_cancel)
+        # Use SIGUSR1 instead of SIGTERM for task cancellation
+        # This prevents conflicts with tasks that register their own SIGTERM handlers
+        signal.signal(signal.SIGUSR1, self.task_cancel)
         signal.signal(signal.SIGINT, self.exit_gracefully)
 
     def task_cancel(self, *args, **kwargs):

--- a/docs/design_notes.md
+++ b/docs/design_notes.md
@@ -82,6 +82,32 @@ In AWX dispatcher, a full queue may put messages into individual worker IPCs.
 This caused bad results, like delaying tasks due to long-running jobs,
 while the pool had many other workers free up in the mean time.
 
+
+### Worker Task Cancelation Signals
+
+Originally, the dispatcher library used **SIGTERM** to forcibly cancel a running task. However,
+some user code (or third-party libraries) register custom SIGTERM handlers, which caused
+collisions and made forcible timeouts/cancellations unreliable.
+
+To avoid these conflicts, dispatcher now uses **SIGUSR1** for per-task cancelation. This means:
+
+1. **Task**: When the dispatcher needs to cancel a running task (for example, due to a timeout),
+   it sends SIGUSR1 to that worker subprocess instead of SIGTERM.
+
+2. **Worker**: In the worker code (`WorkerSignalHandler`), the `SIGUSR1` handler raises
+   `DispatcherCancel`, which immediately stops the current task’s execution path.
+
+3. **Shutdown**: In contrast, a full worker shutdown or system-wide stop
+   can still use SIGTERM or SIGINT. That’s typically not per-task, but a broader
+   action telling the entire worker to exit.
+
+#### Why SIGUSR1
+
+SIGUSR1 is less commonly used by applications, so it’s less likely that user code
+will override it (unlike SIGTERM). This ensures that the dispatcher’s forced cancel
+mechanism remains reliable across a wide variety of user tasks, libraries, or Python
+frameworks that might expect to intercept SIGTERM for graceful shutdown.
+
 ### Notable python tasking systems
 
 https://taskiq-python.github.io/guide/architecture-overview.html#context

--- a/tests/integration/test_signal_handling.py
+++ b/tests/integration/test_signal_handling.py
@@ -1,0 +1,74 @@
+import asyncio
+import inspect
+import time
+
+import pytest
+
+from dispatcher.publish import task
+
+
+@task(queue="test_channel")
+def sigterm_interceptor_task():
+    """
+    This function is top-level in an importable module.
+    The dispatcher sees e.g. "tests.integration.test_signal_handling.sigterm_interceptor_task".
+    """
+    import signal
+    import sys
+
+    def on_sigterm(signum, frame):
+        sys.stdout.write("SIGTERM was intercepted!\n")
+        sys.stdout.flush()
+
+    signal.signal(signal.SIGTERM, on_sigterm)
+    while True:
+        time.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_sigusr1_cancel_avoids_sigterm(apg_dispatcher, pg_control, test_settings, caplog):
+    """
+    Ensures dispatcher uses SIGUSR1, not SIGTERM. This test demonstrates canceling a task via SIGUSR1 without triggering
+    a custom SIGTERM handler.
+    """
+
+    # Verify code implementation uses SIGUSR1
+    from dispatcher.service.pool import PoolWorker
+    from dispatcher.worker.task import WorkerSignalHandler
+    code_init = inspect.getsource(WorkerSignalHandler.__init__)
+    code_cancel = inspect.getsource(PoolWorker.cancel)
+    assert "SIGUSR1" in code_init
+    assert "SIGUSR1" in code_cancel
+
+    # Submit the task
+    uuid_val = "test-sigusr1-cancel-inline"
+    sigterm_interceptor_task.apply_async(uuid=uuid_val, settings=test_settings)
+
+    # Give the dispatcher a moment to start the task
+    await asyncio.sleep(0.3)
+
+    # Cancel the running task
+    # canceled_jobs e.g. [ { "node_id": ..., "worker-0": {...} } ]
+    canceled_jobs = await pg_control.acontrol_with_reply("cancel", data={"uuid": uuid_val}, timeout=2)
+    assert canceled_jobs, "Expected at least some data from the cancel reply."
+    canceled_info = canceled_jobs[0]
+
+    # Wait for the dispatcher to finish cleaning up the task
+    clearing_task = asyncio.create_task(apg_dispatcher.pool.events.work_cleared.wait())
+    await asyncio.wait_for(clearing_task, timeout=5)
+
+    # We want to confirm at least one "worker-X" sub-dict has the correct UUID
+    node_id = canceled_info.pop("node_id", None)
+    assert node_id, "No node_id in reply"
+    assert canceled_info, f"Missing worker data: {canceled_info}"
+
+    # We'll search for any subdict that has 'uuid': our expected value
+    (worker_key, worker_data) = list(canceled_info.items())[0]
+    assert worker_data["uuid"] == uuid_val
+
+    # Wait for the dispatcher to declare all tasks cleared
+    await asyncio.wait_for(apg_dispatcher.pool.events.work_cleared.wait(), timeout=5)
+
+    # Check that 1 task was canceled, and no SIGTERM printout
+    assert apg_dispatcher.pool.canceled_count == 1
+    assert "SIGTERM was intercepted!" not in caplog.text


### PR DESCRIPTION
JIRA: [AAP-41128](https://issues.redhat.com/browse/AAP-41128)

## Description

Changed the dispatcher’s per-task cancellation signal from SIGTERM to SIGUSR1, preventing collisions with user/library SIGTERM handlers. Added an integration test that checks a user-defined SIGTERM handler is never triggered during normal cancellation. Added related docs to the design_notes.md.

## Testing

**Prerequisites**
- Run the dispatcher in a standalone mode (`make postgres`).

**Steps to test**
1. Run: `python -m pytest tests/integration/test_signal_handling.py`
2. Verify the new `test_sigusr1_cancel_avoids_sigterm` passes for both `fork` and `forkserver`, with no sign of `"SIGTERM was intercepted"` in logs.

**Notes**
Lambda-based tasks initially worked with SIGUSR1 but still encountered a SIGTERM at teardown. By defining a top-level `@task` and letting it exit quickly on cancellation, the test remains stable and confirms SIGUSR1 is used properly.