### PR TITLE
Add a `dispatcherctl` command, rework the demo with it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ linters:
 	mypy dispatcher
 
 demo:
-	docker compose up -d
+	docker compose up -d --wait
 
 stop-demo:
 	docker compose down

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,9 @@ linters:
 	isort dispatcher/
 	flake8 dispatcher/
 	mypy dispatcher
+
+demo:
+	docker compose up -d
+
+stop-demo:
+	docker compose down

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- License Badge -->
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/ansible/dispatcher/blob/main/LICENSE)
 
-## Dispatcher
+## Dispatcherd
 
 The dispatcher is a service to run python tasks in subprocesses,
 designed specifically to work well with pg_notify,
@@ -32,10 +32,11 @@ In the "Manual Demo" section, an runnable example of this is given.
 #### Library
 
 The dispatcher `@task()` decorator is used to register tasks.
-
 The [tests/data/methods.py](tests/data/methods.py) module defines some
-dispatcher tasks and the pg_notify channels they will be sent over.
-For more `@task` options, see [docs/task_options.md](docs/task_options.md).
+dispatcher tasks.
+
+The decorator accepts some kwargs (like `queue` below) that will affect task behavior,
+see [docs/task_options.md](docs/task_options.md).
 
 ```python
 from dispatcher.publish import task
@@ -45,7 +46,7 @@ def print_hello():
     print('hello world!!')
 ```
 
-Additionally, you need to configure dispatcher somewhere in your import path.
+Configure dispatcher somewhere in your import path or before running the service.
 This tells dispatcher how to submit tasks to be ran.
 
 ```python
@@ -81,7 +82,7 @@ If you submit a task in an outage of the service, it will be dropped.
 There are 2 ways to run the dispatcher service:
 
 - Importing and running (code snippet below)
-- A CLI entrypoint `dispatcher-standalone` for demo purposes
+- A CLI entrypoint `dispatcherd` for demo purposes
 
 ```python
 from dispatcher import run_service
@@ -92,8 +93,6 @@ run_service()
 ```
 
 Configuration tells how to connect to postgres, and what channel(s) to listen to.
-
-
 
 #### Publisher
 

--- a/dispatcher/cli.py
+++ b/dispatcher/cli.py
@@ -3,13 +3,16 @@ import logging
 import os
 import sys
 
+import yaml
+
 from . import run_service
 from .config import setup
+from .factories import get_control_from_settings
 
 logger = logging.getLogger(__name__)
 
 
-def standalone() -> None:
+def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="CLI entrypoint for dispatcher, mainly intended for testing.")
     parser.add_argument(
         '--log-level',
@@ -24,12 +27,51 @@ def standalone() -> None:
         default='dispatcher.yml',
         help='Path to dispatcher config.',
     )
+    return parser
 
+
+def setup_from_parser(parser) -> argparse.Namespace:
     args = parser.parse_args()
     logging.basicConfig(level=getattr(logging, args.log_level), stream=sys.stdout)
 
     logger.debug(f"Configured standard out logging at {args.log_level} level")
 
     setup(file_path=args.config)
+    return args
 
+
+def standalone() -> None:
+    setup_from_parser(get_parser())
     run_service()
+
+
+def control() -> None:
+    parser = get_parser()
+    parser.add_argument('command', help='The control action to run.')
+    parser.add_argument(
+        '--task',
+        type=str,
+        default=None,
+        help='Task name to filter on.',
+    )
+    parser.add_argument(
+        '--uuid',
+        type=str,
+        default=None,
+        help='Task uuid to filter on.',
+    )
+    parser.add_argument(
+        '--expected-replies',
+        type=int,
+        default=1,
+        help='Expected number of replies, in case you are have more than 1 service running.',
+    )
+    args = setup_from_parser(parser)
+    data = {}
+    for field in ('task', 'uuid'):
+        val = getattr(args, field)
+        if val:
+            data[field] = val
+    ctl = get_control_from_settings()
+    returned = ctl.control_with_reply(args.command, data=data, expected_replies=args.expected_replies)
+    print(yaml.dump(returned, default_flow_style=False))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,9 @@ services:
       POSTGRES_PASSWORD: dispatching
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "dispatch", "-d", "dispatch_db"]
-      interval: 10s
+      interval: 1s
       timeout: 5s
-      retries: 5
+      retries: 20
     ports:
       - "55777:5432"
   dispatcherd1:
@@ -23,10 +23,18 @@ services:
     environment:
       PATH: /dispatcherd/venv/bin:$PATH
       PYTHONPATH: .
-    command: dispatcherd --config=/dispatcherd/dispatcher1.yml
+      DISPATCHER_CONFIG_FILE: /dispatcherd/dispatcher1.yml
+    command: dispatcherd
     depends_on:
       msg_postgres:
         condition: service_healthy
+    volumes:
+      - "./:/dispatcherd/src"
+    healthcheck:
+      test: ["CMD", "dispatcherctl", "alive", "--expected-replies=2"]
+      interval: 1s
+      timeout: 5s
+      retries: 5
   dispatcherd2:
     container_name: dispatcherd2
     build:
@@ -35,7 +43,15 @@ services:
     environment:
       PATH: /dispatcherd/venv/bin:$PATH
       PYTHONPATH: .
-    command: dispatcherd --config=/dispatcherd/dispatcher2.yml
+      DISPATCHER_CONFIG_FILE: /dispatcherd/dispatcher2.yml
+    command: dispatcherd
     depends_on:
       msg_postgres:
         condition: service_healthy
+    volumes:
+      - "./:/dispatcherd/src"
+    healthcheck:
+      test: ["CMD", "dispatcherctl", "alive", "--expected-replies=2"]
+      interval: 1s
+      timeout: 5s
+      retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,28 @@ services:
       retries: 5
     ports:
       - "55777:5432"
+  dispatcherd1:
+    container_name: dispatcherd1
+    working_dir: /dispatcherd
+    build:
+      context: .
+      dockerfile: tools/demo/Dockerfile
+    environment:
+      PATH: /dispatcherd/venv/bin:$PATH
+      PYTHONPATH: .
+    command: dispatcherd --config=/dispatcherd/dispatcher1.yml
+    depends_on:
+      msg_postgres:
+        condition: service_healthy
+  dispatcherd2:
+    container_name: dispatcherd2
+    build:
+      context: .
+      dockerfile: tools/demo/Dockerfile
+    environment:
+      PATH: /dispatcherd/venv/bin:$PATH
+      PYTHONPATH: .
+    command: dispatcherd --config=/dispatcherd/dispatcher2.yml
+    depends_on:
+      msg_postgres:
+        condition: service_healthy

--- a/docs/config.md
+++ b/docs/config.md
@@ -10,15 +10,14 @@ This will result in an error:
 
 > Dispatcher not configured, set DISPATCHER_CONFIG_FILE or call dispatcher.config.setup
 
-This is an error because dispatcher does not have information to connect to a message broker.
-In the case of postgres, that information is the connection information (host, user, password, etc)
+This errors because dispatcher does not know how to connect to a message broker.
+For the demo, that would be the postgres host, user, password, etc.,
 as well as the pg_notify channel to send the message to.
 
 ### Ways to configure
 
 #### From file
 
-The provided entrypoint `dispatcher-standalone` can only use a file, which is how the demo works.
 The demo runs using the `dispatcher.yml` config file at the top-level of this repo.
 
 You can do the same thing in python by:
@@ -29,11 +28,19 @@ from dispatcher.config import setup
 setup(file_path='dispatcher.yml')
 ```
 
-This approach is used by the demo's test script at `tools/write_messages.py`,
-which acts as a "publisher", meaning that it submits tasks over the message
+This is used by the demo's test script at `tools/write_messages.py`,
+which acts as a "publisher", meaning that it submits tasks to the message
 broker to be ran.
-This setup ensures that both the service (`dispatcher-standalone`) and the publisher
+Using `setup` ensures that both the service (`dispatcherd`) and the publisher
 are using the same configuration.
+
+##### With Environment variable
+
+Alternatively, the `DISPATCHER_CONFIG_FILE` environment variable can point to a file. Example:
+
+```
+DISPATCHER_CONFIG_FILE=dispatcher.yml dispatcherd
+```
 
 #### From a dictionary
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
 dependencies = ["pyyaml"]
 
 [project.scripts]
-dispatcher-standalone = "dispatcher.cli:standalone"
+dispatcherd = "dispatcher.cli:standalone"
+dispatcherctl = "dispatcher.cli:control"
 
 [tool.setuptools.packages.find]
 include = ["dispatcher*"]

--- a/run_demo.py
+++ b/run_demo.py
@@ -25,6 +25,15 @@ TEST_MSGS = [
 ]
 
 
+# If we run against more than 1 background task service,
+# we need to wait for that-many replies, so allow this via sys.argv last arg
+expected_count = 1
+try:
+    expected_count = int(sys.argv[-1])
+except ValueError:
+    pass
+
+
 def main():
     print('writing some basic test messages')
     for channel, message in TEST_MSGS:
@@ -44,18 +53,18 @@ def main():
     print('performing a task cancel')
     # we will "find" a task two different ways here
     broker.publish_message(message=json.dumps({'task': 'lambda: __import__("time").sleep(3.1415)', 'uuid': 'foobar'}))
-    canceled_jobs = ctl.control_with_reply('cancel', data={'uuid': 'foobar'})
+    canceled_jobs = ctl.control_with_reply('cancel', data={'uuid': 'foobar'}, expected_replies=expected_count)
     print(json.dumps(canceled_jobs, indent=2))
 
     print('')
     print('finding a running task by its task name')
     broker.publish_message(message=json.dumps({'task': 'lambda: __import__("time").sleep(3.1415)', 'uuid': 'find_by_name'}))
-    running_data = ctl.control_with_reply('running', data={'task': 'lambda: __import__("time").sleep(3.1415)'})
+    running_data = ctl.control_with_reply('running', data={'task': 'lambda: __import__("time").sleep(3.1415)'}, expected_replies=expected_count)
     print(json.dumps(running_data, indent=2))
 
     print('')
     print('getting worker status')
-    worker_data = ctl.control_with_reply('workers')
+    worker_data = ctl.control_with_reply('workers', expected_replies=expected_count)
     print(json.dumps(worker_data, indent=2))
 
     print('')
@@ -72,7 +81,7 @@ def main():
 
     print('')
     print('run bogus control command')
-    worker_data = ctl.control_with_reply('not-a-command')
+    worker_data = ctl.control_with_reply('not-a-command', expected_replies=expected_count)
     print(json.dumps(worker_data, indent=2))
 
     print('writing a message with a delay')
@@ -94,20 +103,20 @@ def main():
 
     print('')
     print('showing delayed tasks in running list')
-    running_data = ctl.control_with_reply('running', data={'task': f'tests.data.methods{MODULE_METHOD_DELIMITER}sleep_function'})
+    running_data = ctl.control_with_reply('running', data={'task': f'tests.data.methods{MODULE_METHOD_DELIMITER}sleep_function'}, expected_replies=expected_count)
     print(json.dumps(running_data, indent=2))
 
     print('')
     print('cancel a delayed task with no reply for demonstration')
     ctl.control('cancel', data={'task': f'tests.data.methods{MODULE_METHOD_DELIMITER}sleep_function'})  # NOTE: no reply
     print('confirmation that it has been canceled')
-    running_data = ctl.control_with_reply('running', data={'task': f'tests.data.methods{MODULE_METHOD_DELIMITER}sleep_function'})
+    running_data = ctl.control_with_reply('running', data={'task': f'tests.data.methods{MODULE_METHOD_DELIMITER}sleep_function'}, expected_replies=expected_count)
     print(json.dumps(running_data, indent=2))
 
     print('')
     print('running alive check a few times')
     for i in range(3):
-        alive = ctl.control_with_reply('alive')
+        alive = ctl.control_with_reply('alive', expected_replies=expected_count)
         print(alive)
 
     print('')

--- a/tools/demo/Dockerfile
+++ b/tools/demo/Dockerfile
@@ -1,0 +1,23 @@
+FROM ghcr.io/linuxcontainers/alpine:latest
+
+WORKDIR /dispatcherd
+
+RUN apk add --no-cache python3 py3-pip && ln -sf python3 /usr/bin/python
+
+RUN python3 -m venv /dispatcherd/venv
+
+RUN echo $pwd
+
+COPY . .
+
+RUN /dispatcherd/venv/bin/pip3 install -e .[pg_notify] --verbose
+
+COPY dispatcher.yml /dispatcherd/dispatcher1.yml
+COPY dispatcher.yml /dispatcherd/dispatcher2.yml
+
+RUN sed -i 's/\(node_id: \)demo-server-a/\1demo-server-1/' /dispatcherd/dispatcher1.yml
+RUN sed -i 's/\(node_id: \)demo-server-a/\1demo-server-2/' /dispatcherd/dispatcher2.yml
+
+RUN sed -i 's/\(host=\)localhost \(port=\)55777/\1msg_postgres \25432/' /dispatcherd/dispatcher1.yml
+RUN sed -i 's/\(host=\)localhost \(port=\)55777/\1msg_postgres \25432/' /dispatcherd/dispatcher2.yml
+

--- a/tools/demo/Dockerfile
+++ b/tools/demo/Dockerfile
@@ -8,9 +8,9 @@ RUN python3 -m venv /dispatcherd/venv
 
 RUN echo $pwd
 
-COPY . .
+COPY . ./src
 
-RUN /dispatcherd/venv/bin/pip3 install -e .[pg_notify] --verbose
+RUN /dispatcherd/venv/bin/pip3 install -e ./src[pg_notify] --verbose
 
 COPY dispatcher.yml /dispatcherd/dispatcher1.yml
 COPY dispatcher.yml /dispatcherd/dispatcher2.yml


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcherd/issues/61

This renames `dispatcher-standalone` to `dispatcherd`, and then adds `dispatcherctl`.

I'm taking advantage of the new entrypoint to remove the 2-terminal-tab instructions from the manual demo. You can just to `docker logs` to see what the server is doing. The `run_demo.py` command doesn't seem to have any problem running against 2 servers as opposed to 1. Everything just happens in duplicate.