### PR TITLE
Take a copy of objects before processing

### DIFF
--- a/dispatcher/service/next_wakeup_runner.py
+++ b/dispatcher/service/next_wakeup_runner.py
@@ -58,7 +58,7 @@ class NextWakeupRunner:
            without calling the callback for anything
         """
         future_wakeup = None
-        for obj in self.wakeup_objects:
+        for obj in list(self.wakeup_objects):
             if obj_wakeup := obj.next_wakeup():
                 if do_processing and (obj_wakeup < current_time):
                     await self.process_object(obj)


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcherd/issues/114

This appears to come specifically from timeout/delay case, which explains why it didn't obviously break everything else.