### PR TITLE
Add control command to show asyncio tasks

### DIFF
--- a/dispatcher/producers/brokered.py
+++ b/dispatcher/producers/brokered.py
@@ -17,7 +17,7 @@ class BrokeredProducer(BaseProducer):
         super().__init__()
 
     async def start_producing(self, dispatcher: DispatcherMain) -> None:
-        self.production_task = asyncio.create_task(self.produce_forever(dispatcher), name=f'{self.broker}_production')
+        self.production_task = asyncio.create_task(self.produce_forever(dispatcher), name=f'{self.broker.__module__}_production')
 
     def all_tasks(self) -> Iterable[asyncio.Task]:
         if self.production_task:

--- a/dispatcher/service/control_tasks.py
+++ b/dispatcher/service/control_tasks.py
@@ -1,3 +1,5 @@
+import asyncio
+import io
 import logging
 
 __all__ = ['running', 'cancel', 'alive', 'workers']
@@ -52,6 +54,24 @@ async def running(dispatcher, **data) -> dict[str, dict]:
 async def cancel(dispatcher, **data) -> dict[str, dict]:
     async with dispatcher.pool.management_lock:
         return await _find_tasks(dispatcher, cancel=True, **data)
+
+
+def _stack_from_task(task: asyncio.Task, limit=6) -> str:
+    buffer = io.StringIO()
+    task.print_stack(file=buffer, limit=limit)
+    return buffer.getvalue()
+
+
+async def aio_tasks(dispatcher, **data) -> dict[str, dict]:
+    ret = {}
+    extra = {}
+    if 'limit' in data:
+        extra['limit'] = data['limit']
+
+    for task in asyncio.all_tasks():
+        task_name = task.get_name()
+        ret[task_name] = {'done': task.done(), 'stack': _stack_from_task(task, **extra)}
+    return ret
 
 
 async def alive(dispatcher, **data) -> dict:

--- a/dispatcher/service/control_tasks.py
+++ b/dispatcher/service/control_tasks.py
@@ -2,7 +2,7 @@ import asyncio
 import io
 import logging
 
-__all__ = ['running', 'cancel', 'alive', 'workers']
+__all__ = ['running', 'cancel', 'alive', 'aio_tasks', 'workers']
 
 
 logger = logging.getLogger(__name__)

--- a/dispatcher/service/main.py
+++ b/dispatcher/service/main.py
@@ -69,7 +69,7 @@ class DispatcherMain:
         "Returns when all the producers have hit their ready event"
         for producer in self.producers:
             existing_tasks = list(producer.all_tasks())
-            wait_task = asyncio.create_task(producer.events.ready_event.wait())
+            wait_task = asyncio.create_task(producer.events.ready_event.wait(), name=f'tmp_{producer}_wait_task')
             existing_tasks.append(wait_task)
             await asyncio.wait(existing_tasks, return_when=asyncio.FIRST_COMPLETED)
             if not wait_task.done():

--- a/run_demo.py
+++ b/run_demo.py
@@ -59,6 +59,18 @@ def main():
     print(json.dumps(worker_data, indent=2))
 
     print('')
+    print('getting main process tasks')
+    task_data_list = ctl.control_with_reply('aio_tasks')
+    for orig_task_data in task_data_list:
+        task_data = orig_task_data.copy()
+        print(f'Task data for node {task_data["node_id"]}')
+        task_data.pop('node_id', None)
+        for task_name, aio_task_data in task_data.items():
+            print(f'  {task_name} is done={aio_task_data["done"]}')
+            print('   trace:')
+            print(aio_task_data['stack'])
+
+    print('')
     print('run bogus control command')
     worker_data = ctl.control_with_reply('not-a-command')
     print(json.dumps(worker_data, indent=2))


### PR DESCRIPTION
As more people are looking at this, and those people either understand asyncio or are getting there, I want to recognize that debugging needs more work. I envision maybe even 5 more control-and-reply commands being added, with one being to run all other debugging control commands and return them in a giant glob. I have filed https://github.com/ansible/dispatcherd/issues/110 concretely as another new one.

For this I wanted to jump straight to the implementation. Here is the demo:

```
getting main process tasks
Task data for node demo-server-a
  management_task is done=False
   trace:
Stack for <Task pending name='management_task' coro=<WorkerPool.manage_workers() running at /home/arominge/repos/dispatcher/dispatcher/service/pool.py:320> wait_for=<Future pending cb=[Task.task_wakeup()]> cb=[done_callback() at /home/arominge/repos/dispatcher/dispatcher/service/asyncio_tasks.py:7]> (most recent call last):
  File "/home/arominge/repos/dispatcher/dispatcher/service/pool.py", line 320, in manage_workers
    await asyncio.wait_for(self.events.management_event.wait(), timeout=self.scaledown_interval)

  next-run-manager-of-trigger_schedule is done=False
   trace:
Stack for <Task pending name='next-run-manager-of-trigger_schedule' coro=<NextWakeupRunner.background_task() running at /home/arominge/repos/dispatcher/dispatcher/service/next_wakeup_runner.py:86> wait_for=<Future pending cb=[Task.task_wakeup()]> cb=[done_callback() at /home/arominge/repos/dispatcher/dispatcher/service/asyncio_tasks.py:7, done_callback() at /home/arominge/repos/dispatcher/dispatcher/service/asyncio_tasks.py:7]> (most recent call last):
  File "/home/arominge/repos/dispatcher/dispatcher/service/next_wakeup_runner.py", line 86, in background_task
    await asyncio.wait_for(self.kick_event.wait(), timeout=delta)

  Task-1 is done=False
   trace:
Stack for <Task pending name='Task-1' coro=<DispatcherMain.main() running at /home/arominge/repos/dispatcher/dispatcher/service/main.py:235> wait_for=<Future pending cb=[Task.task_wakeup()]> cb=[_run_until_complete_cb() at /usr/lib64/python3.12/asyncio/base_events.py:181]> (most recent call last):
  File "/home/arominge/repos/dispatcher/dispatcher/service/main.py", line 235, in main
    await self.events.exit_event.wait()

  dispatcher.brokers.pg_notify_production is done=False
   trace:
Stack for <Task pending name='dispatcher.brokers.pg_notify_production' coro=<BrokeredProducer.produce_forever() running at /home/arominge/repos/dispatcher/dispatcher/producers/brokered.py:37> cb=[done_callback() at /home/arominge/repos/dispatcher/dispatcher/service/asyncio_tasks.py:7]> (most recent call last):
  File "/home/arominge/repos/dispatcher/dispatcher/__init__.py", line 17, in run_service
    loop.run_until_complete(dispatcher.main())
  File "/usr/lib64/python3.12/asyncio/base_events.py", line 678, in run_until_complete
    self.run_forever()
  File "/usr/lib64/python3.12/asyncio/base_events.py", line 645, in run_forever
    self._run_once()
  File "/usr/lib64/python3.12/asyncio/base_events.py", line 1999, in _run_once
    handle._run()
  File "/usr/lib64/python3.12/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/home/arominge/repos/dispatcher/dispatcher/producers/brokered.py", line 37, in produce_forever
    reply_to, reply_payload = await dispatcher.process_message(payload, producer=self, channel=channel)

  results_task is done=False
   trace:
Stack for <Task pending name='results_task' coro=<WorkerPool.read_results_forever() running at /home/arominge/repos/dispatcher/dispatcher/service/pool.py:550> wait_for=<Future pending cb=[_chain_future.<locals>._call_check_cancel() at /usr/lib64/python3.12/asyncio/futures.py:389, Task.task_wakeup()]> cb=[done_callback() at /home/arominge/repos/dispatcher/dispatcher/service/asyncio_tasks.py:7]> (most recent call last):
  File "/home/arominge/repos/dispatcher/dispatcher/service/pool.py", line 550, in read_results_forever
    message = await self.process_manager.read_finished()
```

I think this will help people understand the code a great deal better, even better combined with https://github.com/ansible/dispatcherd/pull/113.

The above shows the expected state of the tasks. The pg_notify reader is a bit weird to read some lines up, but the main line makes sense. More tasks are expected to appear based on workload. I intentionally choose to keep "Task-1" named the same, because it is standard to asyncio, and modifying it isn't direct like `create_task`.