### PR TITLE
More type hints & protocols, refactor `control.py` to be broker-based

### DIFF
--- a/dispatcher/brokers/__init__.py
+++ b/dispatcher/brokers/__init__.py
@@ -4,12 +4,12 @@ from types import ModuleType
 from ..protocols import Broker
 
 
-def get_broker_module(broker_name) -> ModuleType:
+def get_broker_module(broker_name: str) -> ModuleType:
     "Static method to alias import_module so we use a consistent import path"
     return importlib.import_module(f'dispatcher.brokers.{broker_name}')
 
 
-def get_broker(broker_name: str, broker_config: dict, **overrides) -> Broker:
+def get_broker(broker_name: str, broker_config: dict, **overrides) -> Broker:  # type: ignore[no-untyped-def]
     """
     Given the name of the broker in the settings, and the data under that entry in settings,
     return the broker object.

--- a/dispatcher/brokers/pg_notify.py
+++ b/dispatcher/brokers/pg_notify.py
@@ -16,7 +16,7 @@ Thus, all psycopg-lib-specific actions must happen here.
 """
 
 
-async def acreate_connection(**config) -> psycopg.AsyncConnection:
+async def acreate_connection(**config) -> psycopg.AsyncConnection:  # type: ignore[no-untyped-def]
     "Create a new asyncio connection"
     connection = await psycopg.AsyncConnection.connect(**config)
     if not connection.autocommit:
@@ -24,7 +24,7 @@ async def acreate_connection(**config) -> psycopg.AsyncConnection:
     return connection
 
 
-def create_connection(**config) -> psycopg.Connection:
+def create_connection(**config) -> psycopg.Connection:  # type: ignore[no-untyped-def]
     connection = psycopg.Connection.connect(**config)
     if not connection.autocommit:
         connection.set_autocommit(True)
@@ -239,7 +239,7 @@ class ConnectionSaver:
 connection_save = ConnectionSaver()
 
 
-def connection_saver(**config) -> psycopg.Connection:
+def connection_saver(**config) -> psycopg.Connection:  # type: ignore[no-untyped-def]
     """
     This mimics the behavior of Django for tests and demos
     Philosophically, this is used by an application that uses an ORM,
@@ -251,7 +251,7 @@ def connection_saver(**config) -> psycopg.Connection:
     return connection_save._connection
 
 
-async def async_connection_saver(**config) -> psycopg.AsyncConnection:
+async def async_connection_saver(**config) -> psycopg.AsyncConnection:  # type: ignore[no-untyped-def]
     """
     This mimics the behavior of Django for tests and demos
     Philosophically, this is used by an application that uses an ORM,

--- a/dispatcher/control.py
+++ b/dispatcher/control.py
@@ -6,55 +6,35 @@ import uuid
 from typing import Optional, Union
 
 from .factories import get_broker
-from .producers import BrokeredProducer
-from .protocols import Producer
+from .protocols import Broker
 from .service.asyncio_tasks import ensure_fatal
 
 logger = logging.getLogger('awx.main.dispatch.control')
 
 
-class ControlEvents:
-    def __init__(self) -> None:
-        self.exit_event = asyncio.Event()
-
-
-class ControlCallbacks:
-    """This calls follows the same structure as the DispatcherMain class
-
-    it exists to interact with producers, using variables relevant to the particular
-    control message being sent"""
-
-    def __init__(self, queuename: Optional[str], send_data: dict, expected_replies: int) -> None:
+class BrokerCallbacks:
+    def __init__(self, queuename: Optional[str], broker: Broker, send_message: str, expected_replies: int = 1) -> None:
+        self.received_replies: list = []
         self.queuename = queuename
-        self.send_data = send_data
+        self.broker = broker
+        self.send_message = send_message
         self.expected_replies = expected_replies
 
-        # received_replies only tracks the reply message, not the channel name
-        # because they come via a temporary reply_to channel and that is not user-facing
-        self.received_replies: list[Union[dict, str]] = []
-        self.events = ControlEvents()
-        self.shutting_down = False
+    async def connected_callback(self) -> None:
+        await self.broker.apublish_message(self.queuename, self.send_message)
 
-    async def process_message(
-        self, payload: Union[dict, str], producer: Optional[Producer] = None, channel: Optional[str] = None
-    ) -> tuple[Optional[str], Optional[str]]:
-        self.received_replies.append(payload)
-        if self.expected_replies and (len(self.received_replies) >= self.expected_replies):
-            self.events.exit_event.set()
-        return (None, None)
+    async def listen_for_replies(self) -> None:
+        """Listen to the reply channel until we get the expected number of messages
 
-    async def connected_callback(self, producer: Producer) -> None:
-        payload = json.dumps(self.send_data)
-        # Ignore the type hint here because we know it is a brokered producer
-        await producer.notify(channel=self.queuename, message=payload)  # type: ignore[attr-defined]
-        logger.info('Sent control message, expecting replies soon')
-
-    async def main(self) -> None:
-        "Unused"
-        pass
+        This gets ran in a task, and timing out will be accomplished by the main code
+        """
+        async for channel, payload in self.broker.aprocess_notify(connected_callback=self.connected_callback):
+            self.received_replies.append(payload)
+            if len(self.received_replies) >= self.expected_replies:
+                return
 
 
-class Control(object):
+class Control:
     def __init__(self, broker_name: str, broker_config: dict, queue: Optional[str] = None) -> None:
         self.queuename = queue
         self.broker_name = broker_name
@@ -74,63 +54,47 @@ class Control(object):
                 ret.append(json.loads(payload))
         return ret
 
-    async def acontrol_with_reply_internal(self, producer: Producer, send_data: dict, expected_replies: int, timeout: float) -> list[dict]:
-        control_callbacks = ControlCallbacks(self.queuename, send_data, expected_replies)
-
-        await producer.start_producing(control_callbacks)
-        for task in producer.all_tasks():
-            # Make sure we catch errors
-            ensure_fatal(task, exit_event=control_callbacks.events.exit_event)
-
-        await producer.events.ready_event.wait()
-
-        try:
-            await asyncio.wait_for(control_callbacks.events.exit_event.wait(), timeout=timeout)
-        except asyncio.TimeoutError:
-            logger.warning(f'Did not receive {expected_replies} reply in {timeout} seconds, only {len(control_callbacks.received_replies)}')
-
-        control_callbacks.shutting_down = True
-        await producer.shutdown()
-
-        return self.parse_replies(control_callbacks.received_replies)
-
-    def make_producer(self, reply_queue: str) -> Producer:
-        broker = get_broker(self.broker_name, self.broker_config, channels=[reply_queue])
-        return BrokeredProducer(broker, close_on_exit=True)
+    def get_send_message(self, command: str, reply_to: Optional[str] = None, send_data: Optional[dict] = None) -> str:
+        to_send: dict[str, Union[dict, str]] = {'control': command}
+        if reply_to:
+            to_send['reply_to'] = reply_to
+        if send_data:
+            to_send['control_data'] = send_data
+        return json.dumps(to_send)
 
     async def acontrol_with_reply(self, command: str, expected_replies: int = 1, timeout: int = 1, data: Optional[dict] = None) -> list[dict]:
         reply_queue = Control.generate_reply_queue_name()
-        send_data: dict[str, Union[dict, str]] = {'control': command, 'reply_to': reply_queue}
-        if data:
-            send_data['control_data'] = data
+        broker = get_broker(self.broker_name, self.broker_config, channels=[reply_queue])
+        send_message = self.get_send_message(command=command, reply_to=reply_queue, send_data=data)
 
-        return await self.acontrol_with_reply_internal(self.make_producer(reply_queue), send_data, expected_replies, timeout)
+        control_callbacks = BrokerCallbacks(broker=broker, queuename=self.queuename, send_message=send_message, expected_replies=expected_replies)
+
+        listen_task = asyncio.create_task(control_callbacks.listen_for_replies())
+        ensure_fatal(listen_task)
+
+        try:
+            await asyncio.wait_for(listen_task, timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.warning(f'Did not receive {expected_replies} reply in {timeout} seconds, only {len(control_callbacks.received_replies)}')
+            listen_task.cancel()
+
+        return self.parse_replies(control_callbacks.received_replies)
 
     async def acontrol(self, command: str, data: Optional[dict] = None) -> None:
-        send_data: dict[str, Union[dict, str]] = {'control': command}
-        if data:
-            send_data['control_data'] = data
-
-        control_callbacks = ControlCallbacks(self.queuename, send_data, 0)
-        producer = self.make_producer(Control.generate_reply_queue_name())  # reply queue not used
-        await control_callbacks.connected_callback(producer)
+        broker = get_broker(self.broker_name, self.broker_config, channels=[])
+        send_message = self.get_send_message(command=command, send_data=data)
+        await broker.apublish_message(message=send_message)
 
     def control_with_reply(self, command: str, expected_replies: int = 1, timeout: float = 1.0, data: Optional[dict] = None) -> list[dict]:
         logger.info('control-and-reply {} to {}'.format(command, self.queuename))
         start = time.time()
         reply_queue = Control.generate_reply_queue_name()
-        send_data: dict[str, Union[dict, str]] = {'control': command, 'reply_to': reply_queue}
-        if data:
-            send_data['control_data'] = data
+        send_message = self.get_send_message(command=command, reply_to=reply_queue, send_data=data)
 
         broker = get_broker(self.broker_name, self.broker_config, channels=[reply_queue])
 
         def connected_callback() -> None:
-            payload = json.dumps(send_data)
-            if self.queuename:
-                broker.publish_message(channel=self.queuename, message=payload)
-            else:
-                broker.publish_message(message=payload)
+            broker.publish_message(channel=self.queuename, message=send_message)
 
         replies = []
         for channel, payload in broker.process_notify(connected_callback=connected_callback, max_messages=expected_replies, timeout=timeout):
@@ -142,10 +106,6 @@ class Control(object):
 
     def control(self, command: str, data: Optional[dict] = None) -> None:
         "Send message in fire-and-forget mode, as synchronous code. Only for no-reply control."
-        send_data: dict[str, Union[dict, str]] = {'control': command}
-        if data:
-            send_data['control_data'] = data
-
-        payload = json.dumps(send_data)
         broker = get_broker(self.broker_name, self.broker_config)
-        broker.publish_message(channel=self.queuename, message=payload)
+        send_message = self.get_send_message(command=command, send_data=data)
+        broker.publish_message(channel=self.queuename, message=send_message)

--- a/dispatcher/producers/base.py
+++ b/dispatcher/producers/base.py
@@ -4,7 +4,7 @@ from ..protocols import Producer
 
 
 class ProducerEvents:
-    def __init__(self):
+    def __init__(self) -> None:
         self.ready_event = asyncio.Event()
 
 

--- a/dispatcher/producers/brokered.py
+++ b/dispatcher/producers/brokered.py
@@ -9,10 +9,9 @@ logger = logging.getLogger(__name__)
 
 
 class BrokeredProducer(BaseProducer):
-    def __init__(self, broker: Broker, close_on_exit: bool = True) -> None:
+    def __init__(self, broker: Broker) -> None:
         self.production_task: Optional[asyncio.Task] = None
         self.broker = broker
-        self.close_on_exit = close_on_exit
         self.dispatcher: Optional[DispatcherMain] = None
         super().__init__()
 
@@ -50,6 +49,5 @@ class BrokeredProducer(BaseProducer):
                 logger.info(f'Successfully canceled production from {self.broker}')
 
             self.production_task = None
-        if self.close_on_exit:
-            logger.debug(f'Closing {self.broker} connection')
-            await self.broker.aclose()
+
+        await self.broker.aclose()

--- a/dispatcher/protocols.py
+++ b/dispatcher/protocols.py
@@ -3,6 +3,13 @@ from typing import Any, AsyncGenerator, Callable, Coroutine, Iterable, Iterator,
 
 
 class Broker(Protocol):
+    """
+    Describes a messaging broker interface.
+
+    This interface abstracts functionality for sending and receiving messages,
+    both asynchronously and synchronously, and for managing connection lifecycles.
+    """
+
     async def aprocess_notify(
         self, connected_callback: Optional[Optional[Callable[[], Coroutine[Any, Any, None]]]] = None
     ) -> AsyncGenerator[tuple[str, str], None]:
@@ -35,10 +42,23 @@ class Broker(Protocol):
 
 
 class ProducerEvents(Protocol):
+    """
+    Describes an events container for producers.
+
+    Typically provides a signal (like a ready event) to indicate producer readiness.
+    """
+
     ready_event: asyncio.Event
 
 
 class Producer(Protocol):
+    """
+    Describes a task producer interface.
+
+    This interface encapsulates behavior for starting task production,
+    managing its lifecycle, and tracking asynchronous operations.
+    """
+
     events: ProducerEvents
 
     async def start_producing(self, dispatcher: 'DispatcherMain') -> None:
@@ -55,6 +75,13 @@ class Producer(Protocol):
 
 
 class PoolWorker(Protocol):
+    """
+    Describes an individual worker in a task pool.
+
+    It covers the properties and behaviors needed to track a worker’s execution state
+    and control its task processing lifecycle.
+    """
+
     current_task: Optional[dict]
     worker_id: int
 
@@ -70,18 +97,37 @@ class PoolWorker(Protocol):
 
 
 class Queuer(Protocol):
+    """
+    Describes an interface for managing pending tasks.
+
+    It provides a way to iterate over and modify tasks awaiting assignment.
+    """
+
     def __iter__(self) -> Iterator[dict]: ...
 
     def remove_task(self, message: dict) -> None: ...
 
 
 class Blocker(Protocol):
+    """
+    Describes an interface for handling tasks that are temporarily deferred.
+
+    It offers a mechanism to view and manage tasks that cannot run immediately.
+    """
+
     def __iter__(self) -> Iterator[dict]: ...
 
     def remove_task(self, message: dict) -> None: ...
 
 
 class WorkerData(Protocol):
+    """
+    Describes an interface for managing a collection of workers.
+
+    It abstracts how worker instances are iterated over and retrieved,
+    and it provides a lock for safe concurrent updates.
+    """
+
     management_lock: asyncio.Lock
 
     def __iter__(self) -> Iterator[PoolWorker]: ...
@@ -90,6 +136,13 @@ class WorkerData(Protocol):
 
 
 class WorkerPool(Protocol):
+    """
+    Describes an interface for a pool managing task workers.
+
+    It includes core functionality for starting the pool, dispatching tasks,
+    and shutting down the pool in a controlled manner.
+    """
+
     workers: WorkerData
     queuer: Queuer
     blocker: Blocker
@@ -106,6 +159,14 @@ class WorkerPool(Protocol):
 
 
 class DispatcherMain(Protocol):
+    """
+    Describes the primary dispatcher interface.
+
+    This interface defines the contract for the overall task dispatching service,
+    including coordinating task processing, managing the worker pool, and
+    handling delayed or control messages.
+    """
+
     pool: WorkerPool
     delayed_messages: set
 

--- a/dispatcher/service/next_wakeup_runner.py
+++ b/dispatcher/service/next_wakeup_runner.py
@@ -120,6 +120,6 @@ class NextWakeupRunner:
             return [self.asyncio_task]
         return []
 
-    async def shutdown(self):
+    async def shutdown(self) -> None:
         self.shutting_down = True
         await self.kick()

--- a/dispatcher/service/process.py
+++ b/dispatcher/service/process.py
@@ -59,14 +59,17 @@ class ProcessManager:
         self.ctx = multiprocessing.get_context(self.mp_context)
         self.finished_queue: multiprocessing.Queue = self.ctx.Queue()
         self.settings_stash: dict = settings.serialize()  # These are passed to the workers to initialize dispatcher settings
-        self._loop = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
 
-    def get_event_loop(self):
-        if not self._loop:
-            self._loop = asyncio.get_event_loop()
+    def get_event_loop(self) -> asyncio.AbstractEventLoop:
+        if self._loop:
+            return self._loop
+        self._loop = asyncio.get_event_loop()
         return self._loop
 
-    def create_process(self, args: Optional[Iterable[int | str | dict]] = None, kwargs: Optional[dict] = None, **proxy_kwargs) -> ProcessProxy:
+    def create_process(  # type: ignore[no-untyped-def]
+        self, args: Optional[Iterable[int | str | dict]] = None, kwargs: Optional[dict] = None, **proxy_kwargs
+    ) -> ProcessProxy:
         "Returns a ProcessProxy object, which itself contains a Process object, but actual subprocess is not yet started"
         # kwargs allow passing target for substituting the work_loop for testing
         if kwargs is None:

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,3 +2,12 @@
 
 [mypy-dispatcher.control]
 disallow_untyped_defs = True
+
+[mypy-dispatcher.service.*]
+disallow_untyped_defs = True
+
+[mypy-dispatcher.producers.*]
+disallow_untyped_defs = True
+
+[mypy-dispatcher.brokers.*]
+disallow_untyped_defs = True

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -241,7 +241,7 @@ async def test_tasks_in_serial(apg_dispatcher, test_settings):
     await wait_to_receive(apg_dispatcher, 10)
 
     pool = apg_dispatcher.pool
-    assert [pool.finished_count, sum(1 for w in pool.workers.values() if w.current_task), pool.blocker.count(), pool.blocker.discard_count] == [0, 1, 9, 0]
+    assert [pool.finished_count, sum(1 for w in pool.workers if w.current_task), pool.blocker.count(), pool.blocker.discard_count] == [0, 1, 9, 0]
 
 
 @pytest.mark.asyncio
@@ -252,7 +252,7 @@ async def test_tasks_queue_one(apg_dispatcher, test_settings):
     await wait_to_receive(apg_dispatcher, 10)
 
     pool = apg_dispatcher.pool
-    assert [pool.finished_count, sum(1 for w in pool.workers.values() if w.current_task), pool.blocker.count(), pool.blocker.discard_count] == [0, 1, 1, 8]
+    assert [pool.finished_count, sum(1 for w in pool.workers if w.current_task), pool.blocker.count(), pool.blocker.discard_count] == [0, 1, 1, 8]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_broker_callbacks.py
+++ b/tests/unit/test_broker_callbacks.py
@@ -1,0 +1,51 @@
+import json
+import logging
+import pytest
+
+from dispatcher.control import BrokerCallbacks
+from dispatcher.protocols import Broker
+
+
+# Dummy broker that yields first an invalid JSON message and then a valid one.
+class DummyBroker(Broker):
+    async def aprocess_notify(self, connected_callback=None):
+        if connected_callback:
+            await connected_callback()
+        # First yield an invalid JSON string, then a valid one.
+        yield ("reply_channel", "invalid json")
+        yield ("reply_channel", json.dumps({"result": "ok"}))
+
+    async def apublish_message(self, channel, message):
+        # No-op for testing.
+        return
+
+    async def aclose(self):
+        return
+
+    def process_notify(self, connected_callback=None, timeout: float = 5.0, max_messages: int = 1):
+        # Not used in this test.
+        yield ("reply_channel", "")
+
+    def publish_message(self, channel=None, message=None):
+        return
+
+    def close(self):
+        return
+
+
+@pytest.mark.asyncio
+async def test_listen_for_replies_with_invalid_json(caplog):
+    caplog.set_level(logging.WARNING)
+    dummy_broker = DummyBroker()
+    callbacks = BrokerCallbacks(
+        queuename="reply_channel",
+        broker=dummy_broker,
+        send_message="{}",
+        expected_replies=1
+    )
+    await callbacks.listen_for_replies()
+    # The invalid JSON should be ignored and only the valid message appended.
+    assert len(callbacks.received_replies) == 1
+    assert callbacks.received_replies[0] == {"result": "ok"}
+    # Verify that a warning was logged for the malformed message.
+    assert any("Invalid JSON" in record.message for record in caplog.records)

--- a/tests/unit/test_connection_saver.py
+++ b/tests/unit/test_connection_saver.py
@@ -1,0 +1,70 @@
+import threading
+import asyncio
+import pytest
+
+from dispatcher.brokers.pg_notify import connection_saver, async_connection_saver, connection_save
+
+# Define a dummy connection object that supports both sync and async close methods.
+class DummyConnection:
+    def __init__(self):
+        self.closed = False
+    def close(self):
+        self.closed = True
+    async def aclose(self):
+        self.close()
+
+connection_create_count = 0
+
+def dummy_create_connection(**config):
+    global connection_create_count
+    connection_create_count += 1
+    return DummyConnection()
+
+@pytest.fixture(autouse=True)
+def reset_sync(monkeypatch):
+    global connection_create_count
+    connection_create_count = 0
+    monkeypatch.setattr("dispatcher.brokers.pg_notify.create_connection", dummy_create_connection)
+    connection_save._connection = None
+
+def test_connection_saver_thread_safety():
+    results = []
+    def worker():
+        res = connection_saver(foo="bar")
+        results.append(res)
+
+    threads = [threading.Thread(target=worker) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    # Ensure all threads got the same connection object.
+    assert all(r is results[0] for r in results)
+    # Ensure only one connection was created.
+    assert connection_create_count == 1
+    # Check that the connection supports close() properly.
+    results[0].close()
+    assert results[0].closed is True
+
+@pytest.mark.asyncio
+async def test_async_connection_saver_thread_safety(monkeypatch):
+    global connection_create_count
+    connection_create_count = 0
+
+    async def dummy_acreate_connection(**config):
+        global connection_create_count
+        connection_create_count += 1
+        return DummyConnection()
+
+    monkeypatch.setattr("dispatcher.brokers.pg_notify.acreate_connection", dummy_acreate_connection)
+    connection_save._async_connection = None
+
+    async def worker():
+        return await async_connection_saver(foo="bar")
+    results = await asyncio.gather(*[worker() for _ in range(10)])
+    # Ensure all tasks returned the same connection object.
+    assert all(r is results[0] for r in results)
+    # Ensure only one async connection was created.
+    assert connection_create_count == 1
+    await results[0].aclose()
+    assert results[0].closed is True

--- a/tests/unit/test_control_cleanup.py
+++ b/tests/unit/test_control_cleanup.py
@@ -1,0 +1,97 @@
+import asyncio
+import json
+import pytest
+
+from dispatcher.control import Control, BrokerCallbacks
+from dispatcher.protocols import Broker
+
+# Dummy broker implementation for testing cleanup.
+class DummyBroker(Broker):
+    def __init__(self):
+        self.aclose_called = False
+        self.close_called = False
+        self.sent_message = None
+
+    async def aprocess_notify(self, connected_callback=None):
+        if connected_callback:
+            await connected_callback()
+        # Yield one valid reply message.
+        yield ("dummy_channel", json.dumps({"result": "ok"}))
+
+    async def apublish_message(self, channel=None, message=""):
+        self.sent_message = message
+
+    async def aclose(self):
+        self.aclose_called = True
+
+    def process_notify(self, connected_callback=None, timeout: float = 5.0, max_messages: int = 1):
+        if connected_callback:
+            connected_callback()
+        # Yield one valid reply message.
+        yield ("dummy_channel", json.dumps({"result": "ok"}))
+
+    def publish_message(self, channel=None, message=""):
+        self.sent_message = message
+
+    def close(self):
+        self.close_called = True
+
+# Test for async control with reply cleanup
+@pytest.mark.asyncio
+async def test_acontrol_with_reply_resource_cleanup(monkeypatch):
+    dummy_broker = DummyBroker()
+
+    def dummy_get_broker(broker_name, broker_config, channels=None):
+        return dummy_broker
+
+    monkeypatch.setattr("dispatcher.control.get_broker", dummy_get_broker)
+
+    control = Control(broker_name="dummy", broker_config={})
+    result = await control.acontrol_with_reply(
+        command="test_command", expected_replies=1, timeout=2, data={"key": "value"}
+    )
+    assert result == [{"result": "ok"}]
+    assert dummy_broker.aclose_called is True
+
+# Test for async control (fire-and-forget) cleanup
+@pytest.mark.asyncio
+async def test_acontrol_resource_cleanup(monkeypatch):
+    dummy_broker = DummyBroker()
+
+    def dummy_get_broker(broker_name, broker_config, channels=None):
+        return dummy_broker
+
+    monkeypatch.setattr("dispatcher.control.get_broker", dummy_get_broker)
+
+    control = Control(broker_name="dummy", broker_config={})
+    await control.acontrol(command="test_command", data={"foo": "bar"})
+    # In acontrol, broker.aclose() should be called.
+    assert dummy_broker.aclose_called is True
+
+# Test for synchronous control_with_reply cleanup
+def test_control_with_reply_resource_cleanup(monkeypatch):
+    dummy_broker = DummyBroker()
+
+    def dummy_get_broker(broker_name, broker_config, channels=None):
+        return dummy_broker
+
+    monkeypatch.setattr("dispatcher.control.get_broker", dummy_get_broker)
+
+    control = Control(broker_name="dummy", broker_config={}, queue="test_queue")
+    result = control.control_with_reply(command="test_command", expected_replies=1, timeout=2, data={"foo": "bar"})
+    assert result == [{"result": "ok"}]
+    # For sync methods, broker.close() should be called.
+    assert dummy_broker.close_called is True
+
+# Test for synchronous control (fire-and-forget) cleanup
+def test_control_resource_cleanup(monkeypatch):
+    dummy_broker = DummyBroker()
+
+    def dummy_get_broker(broker_name, broker_config, channels=None):
+        return dummy_broker
+
+    monkeypatch.setattr("dispatcher.control.get_broker", dummy_get_broker)
+
+    control = Control(broker_name="dummy", broker_config={}, queue="test_queue")
+    control.control(command="test_command", data={"foo": "bar"})
+    assert dummy_broker.close_called is True

--- a/tests/unit/test_next_wakeup_runner_errors.py
+++ b/tests/unit/test_next_wakeup_runner_errors.py
@@ -1,0 +1,46 @@
+import time
+import pytest
+from dispatcher.service.next_wakeup_runner import NextWakeupRunner, HasWakeup
+
+
+# Dummy object that implements HasWakeup.
+class DummySchedule(HasWakeup):
+    def __init__(self, wakeup_time: float):
+        self._wakeup_time = wakeup_time
+
+    def next_wakeup(self) -> float:
+        return self._wakeup_time
+
+# Dummy process_object that simulates successful processing by pushing wakeup time forward.
+async def dummy_process_object(schedule: DummySchedule) -> None:
+    # Simulate processing by adding 10 seconds.
+    schedule._wakeup_time += 10
+
+# Dummy process_object that raises an exception.
+async def failing_process_object(schedule: DummySchedule) -> None:
+    raise ValueError("Processing error")
+
+@pytest.mark.asyncio
+async def test_process_wakeups_normal():
+    # Set up a dummy schedule with a wakeup time in the past.
+    past_time = time.monotonic() - 5
+    schedule = DummySchedule(past_time)
+    # Use dummy_process_object that adds 10 seconds.
+    runner = NextWakeupRunner([schedule], dummy_process_object)
+    current_time = time.monotonic()
+    next_wakeup = await runner.process_wakeups(current_time)
+    # The wakeup time should now be 10 seconds later than the original past time.
+    assert next_wakeup == schedule._wakeup_time
+    # Also, since the schedule was processed, it should not return None.
+    assert next_wakeup is not None
+
+@pytest.mark.asyncio
+async def test_process_wakeups_error_propagation():
+    # Set up a dummy schedule with a wakeup time in the past.
+    past_time = time.monotonic() - 5
+    schedule = DummySchedule(past_time)
+    # Use failing_process_object that raises an exception.
+    runner = NextWakeupRunner([schedule], failing_process_object)
+    current_time = time.monotonic()
+    with pytest.raises(ValueError, match="Processing error"):
+        await runner.process_wakeups(current_time)


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcherd/issues/109

Fixes https://github.com/ansible/dispatcherd/issues/124

Confirmed that the demo still looks good with this change.

This does make structural changes to how control-and-reply works, but I think that is all for the better.