### PR TITLE
Allow running control tasks from worker

### DIFF
--- a/dispatcherd/protocols.py
+++ b/dispatcherd/protocols.py
@@ -164,7 +164,7 @@ class WorkerPool(Protocol):
     queuer: Queuer
     blocker: Blocker
 
-    async def start_working(self, forking_lock: asyncio.Lock, exit_event: Optional[asyncio.Event] = None) -> None:
+    async def start_working(self, dispatcher: 'DispatcherMain', exit_event: Optional[asyncio.Event] = None) -> None:
         """Start persistent asyncio tasks, including asychronously starting worker subprocesses"""
         ...
 
@@ -186,7 +186,7 @@ class DispatcherMain(Protocol):
 
     pool: WorkerPool
     delayed_messages: set
-    lock_fd: asyncio.Lock  # Forking and locking may need to be serialized, which this does
+    fd_lock: asyncio.Lock  # Forking and locking may need to be serialized, which this does
 
     async def main(self) -> None:
         """This is the method that runs the service, bring your own event loop"""

--- a/dispatcherd/protocols.py
+++ b/dispatcherd/protocols.py
@@ -186,6 +186,7 @@ class DispatcherMain(Protocol):
 
     pool: WorkerPool
     delayed_messages: set
+    lock_fd: asyncio.Lock  # Forking and locking may need to be serialized, which this does
 
     async def main(self) -> None:
         """This is the method that runs the service, bring your own event loop"""
@@ -193,6 +194,10 @@ class DispatcherMain(Protocol):
 
     async def connected_callback(self, producer: Producer) -> None:
         """Called by producers when they are connected"""
+        ...
+
+    async def get_control_result(self, action: str, control_data: Optional[dict] = None) -> dict:
+        """Used by WorkerPool if a task needs to run a local control task"""
         ...
 
     async def process_message(

--- a/docs/message_formats.md
+++ b/docs/message_formats.md
@@ -56,3 +56,10 @@ it must identify itself, and identify the event. For example:
     "event": "ready"
 }
 ```
+
+This is used for several core functions of dispatcherd.
+These include notifying the parent of:
+ - finishing a task, meaning that worker is ready for new task
+ - entering main loop, meaning that worker has started up
+ - control actions triggered from the task logic
+ - shutting down, confirming it is safe to join process

--- a/tests/data/methods.py
+++ b/tests/data/methods.py
@@ -52,3 +52,9 @@ def use_callable_queue():
 class RunJob:
     def run(self):
         print('successful run using callable queue with class')
+
+
+@task(bind=True)
+def prints_running_tasks(binder):
+    r = binder.control('running')
+    print(r)

--- a/tests/unit/service/test_worker_liveness.py
+++ b/tests/unit/service/test_worker_liveness.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
 from unittest import mock
+from types import SimpleNamespace
 
 import pytest
 
@@ -17,7 +18,8 @@ async def test_detect_unexpectedly_dead_worker(test_settings, caplog):
     # Create a pool with one worker and start it
     pm = ProcessManager(settings=test_settings)
     pool = WorkerPool(pm, min_workers=1, max_workers=5)
-    await pool.start_working(asyncio.Lock())
+    dispatcher = SimpleNamespace(fd_lock=asyncio.Lock(), exit_event=asyncio.Event())
+    await pool.start_working(dispatcher)
     await pool.events.workers_ready.wait()
 
     # Get the ready worker and assign a task

--- a/tests/unit/worker/test_task_worker.py
+++ b/tests/unit/worker/test_task_worker.py
@@ -1,3 +1,5 @@
+import multiprocessing
+
 from dispatcherd.publish import task
 from dispatcherd.worker.task import TaskWorker
 
@@ -13,5 +15,8 @@ def test_run_method_with_bind(registry):
 
     dmethod = registry.get_from_callable(my_bound_task)
 
-    worker = TaskWorker(1, registry=registry)
-    worker.run_callable({"task": dmethod.serialize_task(), "uuid": "12345"})
+    worker = TaskWorker(1, registry=registry, message_queue=multiprocessing.Queue(), finished_queue=multiprocessing.Queue())
+    worker.run_callable({
+        "task": dmethod.serialize_task(),
+        "uuid": "12345"
+    })


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcherd/issues/71

I just want to demonstrate the gross things so other people don't feel bad doing them, in case someone else goes to pick this up.

From logs running this new test:

```
DEBUG:dispatcher.service.queuer:Dispatching task (uuid=b00b237a-d7bb-4bb0-97e1-98cd0050f1bf) to worker (id=0)
DEBUG:dispatcher.service.pool:Dispatching task (uuid=b00b237a-d7bb-4bb0-97e1-98cd0050f1bf) to worker (id=0)
DEBUG:dispatcher.worker.task:task (uuid=b00b237a-d7bb-4bb0-97e1-98cd0050f1bf) starting tests.data.methods.prints_running_tasks(*[]) on worker 0
{'worker-0': {'task': 'tests.data.methods.prints_running_tasks', 'time_pub': 1741794622.4742262, 'uuid': 'b00b237a-d7bb-4bb0-97e1-98cd0050f1bf', 'args': [], 'kwargs': {}, 'channel': 'test_channel'}}
DEBUG:dispatcher.service.pool:Worker 0 finished task (uuid=b00b237a-d7bb-4bb0-97e1-98cd0050f1bf), ct=0
```

So that's it, that's what we need.

Clearly, the interfaces could use some polishing. See https://github.com/ansible/dispatcherd/pull/121. Here, we're passing some unnecessary data since we passed a whole `DispatcherMain` anyway. But we should prioritize this as a feature before making it completely pretty.