### PR TITLE
UNLISTEN when done with session

### DIFF
--- a/dispatcher/brokers/pg_notify.py
+++ b/dispatcher/brokers/pg_notify.py
@@ -120,7 +120,7 @@ class Broker:
         """
         return psycopg.sql.SQL("LISTEN {};").format(psycopg.sql.Identifier(channel))
 
-    def get_unlisten_query(self) -> psycopg.sql.Composed:
+    def get_unlisten_query(self) -> psycopg.sql.SQL:
         """Stops listening on all channels for current session, see pg_notify docs"""
         return psycopg.sql.SQL("UNLISTEN *;")
 


### PR DESCRIPTION
When working on https://github.com/ansible/dispatcherd/pull/113 I discovered a strange bug.

When running `./run_demo.py`, sometimes the "aio_tasks" command would incorrectly get the output of the "workers" command, or "running" command. Strange... nothing in the code here seemed could obviously explain that. After all, we are using an ephemeral reply channel with a `uuid4`. How could we get messages from _old_ commands?

There are 2 services running in this case, and that command only listened for 1 reply. So yes, the next reply was still in-flight, but this still doesn't explain things. In the `control.py` module we create a broker using just the reply channel.

The key here is that we _never closed the connection_ and that connection _was still subscribed_ to the channel from the last control-and-reply command. Yes, that means that the implementation of `control_and_reply` would accumulate listening channels forever.

From the docs, it appears that this `UNLISTEN` command also drops all active notifications in the session, implying there's no need to clear the current buffer. Testing also seems to show everything is working as intended.