### PR TITLE
Start running synchronous tests, separate from asyncio tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,10 @@ jobs:
         run: pip install -e .[pg_notify,metrics]
       - run: make postgres
       - run: pip install pytest pytest-asyncio httpx
-      - run: pytest tests/unit tests/integration -vv -s
+      - name: Run synchronous tests
+        run: pytest tests/ -vv -s
+      - name: Run pytest-asyncio tests
+        run: pytest tests/ -vv -s -m asyncio
 
   black:
     name: Run black

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 DOCKER_COMPOSE ?= docker compose
+TEST_DIRS ?= tests/
 
 
 # Mostly copied from DAB
@@ -28,3 +29,8 @@ demo:
 
 stop-demo:
 	docker compose down
+
+## Runs pytest synchronous and async tests in different processes
+test:
+	pytest $(TEST_DIRS)
+	pytest $(TEST_DIRS) -m "asyncio"

--- a/dispatcherd/factories.py
+++ b/dispatcherd/factories.py
@@ -157,7 +157,7 @@ def generate_settings_schema(settings: LazySettings = global_settings) -> dict:
 
     ret['service']['metrics_kwargs'] = schema_for_cls(DispatcherMetricsServer)
     ret['service']['process_manager_kwargs'] = {}
-    pm_classes = (process.ProcessManager, process.ForkServerManager)
+    pm_classes = (process.ProcessManager, process.ForkServerManager, process.SpawnServerManager)
     for pm_cls in pm_classes:
         ret['service']['process_manager_kwargs'].update(schema_for_cls(pm_cls))
     ret['service']['process_manager_cls'] = str(Literal[tuple(pm_cls.__name__ for pm_cls in pm_classes)])

--- a/dispatcherd/protocols.py
+++ b/dispatcherd/protocols.py
@@ -196,6 +196,20 @@ class SharedAsyncObjects:
     forking_and_connecting_lock: asyncio.Lock  # Forking and locking may need to be serialized, which this does
 
 
+class PoolEvents:
+    """
+    Container for events related to the WorkerPool
+
+    These have so far been events triggered _by_ the worker pool.
+    This is useful for writing tests or 3rd party customization of the main loop.
+    """
+
+    queue_cleared: asyncio.Event
+    work_cleared: asyncio.Event = asyncio.Event()
+    management_event: asyncio.Event = asyncio.Event()
+    workers_ready: asyncio.Event = asyncio.Event()
+
+
 class WorkerPool(Protocol):
     """
     Describes an interface for a pool managing task workers.
@@ -208,6 +222,7 @@ class WorkerPool(Protocol):
     queuer: Queuer
     blocker: Blocker
     shared: SharedAsyncObjects
+    finished_count: int
 
     async def start_working(self, dispatcher: 'DispatcherMain') -> None:
         """Start persistent asyncio tasks, including asychronously starting worker subprocesses"""

--- a/dispatcherd/protocols.py
+++ b/dispatcherd/protocols.py
@@ -222,6 +222,7 @@ class WorkerPool(Protocol):
     queuer: Queuer
     blocker: Blocker
     shared: SharedAsyncObjects
+    events: PoolEvents
     finished_count: int
 
     async def start_working(self, dispatcher: 'DispatcherMain') -> None:

--- a/dispatcherd/testing/__init__.py
+++ b/dispatcherd/testing/__init__.py
@@ -1,0 +1,4 @@
+from .asyncio import adispatcher_service
+from .subprocess import dispatcher_service
+
+__all__ = ['adispatcher_service', 'dispatcher_service']

--- a/dispatcherd/testing/asyncio.py
+++ b/dispatcherd/testing/asyncio.py
@@ -1,0 +1,35 @@
+import asyncio
+import contextlib
+import logging
+from typing import Any, AsyncGenerator
+
+from ..config import DispatcherSettings
+from ..factories import from_settings
+from ..service.main import DispatcherMain
+
+logger = logging.getLogger(__name__)
+
+
+@contextlib.asynccontextmanager
+async def adispatcher_service(config: dict) -> AsyncGenerator[DispatcherMain, Any]:
+    dispatcher = None
+    try:
+        settings = DispatcherSettings(config)
+        dispatcher = from_settings(settings=settings)  # type: ignore[arg-type]
+
+        await asyncio.wait_for(dispatcher.connect_signals(), timeout=1)
+        await asyncio.wait_for(dispatcher.start_working(), timeout=1)
+        await asyncio.wait_for(dispatcher.wait_for_producers_ready(), timeout=1)
+        await asyncio.wait_for(dispatcher.pool.events.workers_ready.wait(), timeout=1)
+
+        assert dispatcher.pool.finished_count == 0  # sanity
+        assert dispatcher.control_count == 0
+
+        yield dispatcher
+    finally:
+        if dispatcher:
+            try:
+                await dispatcher.shutdown()
+                await dispatcher.cancel_tasks()
+            except Exception:
+                logger.exception('shutdown had error')

--- a/dispatcherd/testing/subprocess.py
+++ b/dispatcherd/testing/subprocess.py
@@ -36,8 +36,7 @@ async def asyncio_target(config: dict, comms: CommunicationItems) -> None:
         comms.q_out.put('ready')
 
         events: dict[str, asyncio.Event] = {}
-        for event_name in comms.main_events:
-            events[event_name] = getattr(dispatcher.events, event_name)
+        events['exit_event'] = dispatcher.shared.exit_event
         for event_name in comms.pool_events:
             events[event_name] = getattr(dispatcher.pool.events, event_name)
 

--- a/dispatcherd/testing/subprocess.py
+++ b/dispatcherd/testing/subprocess.py
@@ -1,0 +1,132 @@
+import asyncio
+import contextlib
+import logging
+import multiprocessing
+import sys
+import traceback
+from multiprocessing.context import BaseContext
+from types import ModuleType
+from typing import Union
+
+from .asyncio import adispatcher_service
+
+logger = logging.getLogger(__name__)
+
+
+class CommunicationItems:
+    """Various things used for communication between the parent process and the subprocess service
+
+    When using the dispatcher_service context manager, this is yielded to be used by tests.
+    Checking q_out can allow waiting for dispatcher events in synchronous code, like clearing of work queue.
+
+    This will be passed in the call to the subprocess.
+    """
+
+    def __init__(self, main_events: tuple[str], pool_events: tuple[str], context: Union[BaseContext, ModuleType]) -> None:
+        self.q_in: multiprocessing.Queue = context.Queue()
+        self.q_out: multiprocessing.Queue = context.Queue()
+        self.main_events = main_events
+        self.pool_events = pool_events
+
+
+async def asyncio_target(config: dict, comms: CommunicationItems) -> None:
+    """Replaces the DispatcherMain.main method, similar to how most asyncio tests work"""
+    loop = asyncio.get_event_loop()
+    async with adispatcher_service(config) as dispatcher:
+        comms.q_out.put('ready')
+
+        events: dict[str, asyncio.Event] = {}
+        for event_name in comms.main_events:
+            events[event_name] = getattr(dispatcher.events, event_name)
+        for event_name in comms.pool_events:
+            events[event_name] = getattr(dispatcher.pool.events, event_name)
+
+        event_tasks: dict[str, asyncio.Task] = {}
+        for event_name, event in events.items():
+            event_tasks[event_name] = asyncio.create_task(event.wait(), name=f'waiting_for_{event_name}')
+
+        new_message_task = None
+
+        while True:
+            if new_message_task is None:
+                new_message_task = loop.run_in_executor(None, comms.q_in.get)
+
+            all_tasks = list(event_tasks.values()) + [new_message_task]
+            await asyncio.wait(all_tasks, return_when=asyncio.FIRST_COMPLETED)
+
+            # Update our parent process with any events they requested from us
+            for event_name, event in events.items():
+                if event.is_set():
+                    comms.q_out.put(event_name)
+                event.clear()
+                event_tasks[event_name] = asyncio.create_task(event.wait())
+
+            # If no no instructions came from parent then work is done, continue loop
+            if not new_message_task.done():
+                continue
+
+            message = new_message_task.result()
+            new_message_task = None
+
+            if message == 'stop':
+                print('shutting down pool server')
+                for event in events.values():
+                    event.set()  # close out other tasks
+                # NOTE: the context manager calls .shutdown
+                break
+            else:
+                eval(message)
+
+
+def subprocess_main(config, comms):
+    """The subprocess (synchronous) target for the testing dispatcherd service"""
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(asyncio_target(config, comms))
+    except Exception:
+        # The main process is very likely waiting for message of an event
+        # and exceptions may not automatically halt the test, so give a value
+        comms.q_out.put('error')
+        stack_trace = traceback.format_exc()
+        comms.q_out.put(stack_trace)
+        raise
+    finally:
+        loop.close()
+
+
+@contextlib.contextmanager
+def dispatcher_service(config, main_events=(), pool_events=()):
+    """Testing utility to run a dispatcherd service as a subprocess
+
+    Note this is likely to have problems if mixed with code running asyncio loops.
+    It is mainly intended to be called from synchronous python.
+    """
+    ctx = multiprocessing.get_context('fork')
+    comms = CommunicationItems(main_events=main_events, pool_events=pool_events, context=ctx)
+    process = multiprocessing.Process(target=subprocess_main, args=(config, comms))
+    try:
+        process.start()
+        ready_msg = comms.q_out.get()
+        if ready_msg != 'ready':
+            if ready_msg == 'error':
+                tb = comms.q_out.get()
+                print(tb)
+            raise RuntimeError(f'Never got "ready" message from server, got {ready_msg}')
+        yield comms
+    finally:
+        comms.q_in.put('stop')
+        process.join(timeout=1)
+        if process.is_alive():
+            print(f"Process {process.pid} did not exit after stop message, sending SIGTERM")
+            process.terminate()  # SIGTERM
+            process.join(timeout=1)
+
+            if process.is_alive():
+                print(f"Process {process.pid} still alive after SIGTERM, sending SIGKILL")
+                process.kill()
+                process.join(timeout=1)
+
+        comms.q_in.close()
+        comms.q_out.close()
+        sys.stdout.flush()
+        sys.stderr.flush()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,4 @@ metrics = ["uvicorn[standard]", "prometheus-client"]
 
 [tool.pytest.ini_options]
 log_cli_level = "DEBUG"
+addopts = "-m 'not asyncio'"

--- a/schema.json
+++ b/schema.json
@@ -43,7 +43,7 @@
     "process_manager_kwargs": {
       "preload_modules": "typing.Optional[list[str]]"
     },
-    "process_manager_cls": "typing.Literal['ProcessManager', 'ForkServerManager']"
+    "process_manager_cls": "typing.Literal['ProcessManager', 'ForkServerManager', 'SpawnServerManager']"
   },
   "publish": {
     "default_broker": "str"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,7 @@ def clear_connection():
     Tests will do a lot of unthoughtful forking, and connections can not
     be shared accross processes.
     """
+    yield
     if connection_save._connection:
         connection_save._connection.close()
         connection_save._connection = None

--- a/tests/integration/test_control_tasks.py
+++ b/tests/integration/test_control_tasks.py
@@ -1,0 +1,76 @@
+import pytest
+import json
+from typing import Generator
+import time
+
+from dispatcherd.testing.subprocess import dispatcher_service, CommunicationItems
+from dispatcherd.factories import get_publisher_from_settings, get_control_from_settings
+from dispatcherd.config import DispatcherSettings
+from dispatcherd.protocols import Broker
+
+from tests.conftest import CONNECTION_STRING
+
+
+BASIC_CONFIG = {
+    "version": 2,
+    "brokers": {
+        "pg_notify": {
+            "channels": ['test_channel', 'test_channel2', 'test_channel3'],
+            "config": {'conninfo': CONNECTION_STRING},
+            "sync_connection_factory": "dispatcherd.brokers.pg_notify.connection_saver",
+            "default_publish_channel": "test_channel"
+        }
+    }
+}
+
+
+@pytest.fixture
+def pg_dispatcher(scope='module') -> Generator[CommunicationItems, None, None]:
+    with dispatcher_service(BASIC_CONFIG, pool_events=('work_cleared',)) as comms:
+        yield comms
+
+
+@pytest.fixture(scope='module')
+def pg_broker() -> Generator[Broker, None, None]:
+    settings = DispatcherSettings(BASIC_CONFIG)
+    return get_publisher_from_settings(settings=settings)
+
+
+@pytest.fixture(scope='module')
+def pg_control():
+    settings = DispatcherSettings(BASIC_CONFIG)
+    return get_control_from_settings(settings=settings)
+
+
+def test_run_lambda_function(pg_dispatcher, pg_broker):
+    pg_broker.publish_message(message='lambda: "This worked!"')
+    message = pg_dispatcher.q_out.get(timeout=1)
+    assert message == 'work_cleared'
+
+
+def test_get_running_jobs(pg_dispatcher, pg_broker, pg_control, get_worker_data):
+    msg = json.dumps({'task': 'lambda: __import__("time").sleep(3.1415)', 'uuid': 'find_me'})
+
+    pg_broker.publish_message(message=msg)
+
+    running_jobs = pg_control.control_with_reply('running', timeout=1)
+
+    running_job = get_worker_data(running_jobs)
+
+    assert running_job['uuid'] == 'find_me'
+
+
+def test_cancel_task(pg_dispatcher, pg_broker, pg_control, get_worker_data):
+    msg = json.dumps({'task': 'lambda: __import__("time").sleep(3.1415)', 'uuid': 'foobar'})
+    pg_broker.publish_message(message=msg)
+
+    time.sleep(0.2)
+    canceled_jobs = pg_control.control_with_reply('cancel', data={'uuid': 'foobar'}, timeout=1)
+    canceled_message = get_worker_data(canceled_jobs)
+    assert canceled_message['uuid'] == 'foobar'
+
+    start = time.time()
+    status = pg_dispatcher.q_out.get(timeout=1)
+    assert status == 'work_cleared'
+    delta = time.time() - start
+    assert delta < 1.0  # less than sleep in test

--- a/tests/integration/test_metrics_use.py
+++ b/tests/integration/test_metrics_use.py
@@ -7,6 +7,7 @@ import pytest
 import pytest_asyncio
 
 from dispatcherd.protocols import DispatcherMain
+from dispatcherd.testing.asyncio import adispatcher_service
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +25,8 @@ def metrics_config():
 
 
 @pytest_asyncio.fixture
-async def ametrics_dispatcher(metrics_config, adispatcher_factory) -> AsyncIterator[DispatcherMain]:
-    async with adispatcher_factory(metrics_config) as dispatcher:
+async def ametrics_dispatcher(metrics_config) -> AsyncIterator[DispatcherMain]:
+    async with adispatcher_service(metrics_config) as dispatcher:
         yield dispatcher
 
 

--- a/tests/integration/test_socket_use.py
+++ b/tests/integration/test_socket_use.py
@@ -8,9 +8,9 @@ import pytest_asyncio
 
 from dispatcherd.config import DispatcherSettings
 from dispatcherd.control import Control
-from dispatcherd.factories import from_settings, get_control_from_settings, get_publisher_from_settings
+from dispatcherd.factories import get_control_from_settings, get_publisher_from_settings
 from dispatcherd.protocols import DispatcherMain
-from dispatcherd.service.control_tasks import _stack_from_task
+from dispatcherd.testing.asyncio import adispatcher_service
 
 logger = logging.getLogger(__name__)
 
@@ -31,8 +31,8 @@ def socket_settings(socket_config):
 
 
 @pytest_asyncio.fixture
-async def asock_dispatcher(socket_config, adispatcher_factory) -> AsyncIterator[DispatcherMain]:
-    async with adispatcher_factory(socket_config) as dispatcher:
+async def asock_dispatcher(socket_config) -> AsyncIterator[DispatcherMain]:
+    async with adispatcher_service(socket_config) as dispatcher:
         yield dispatcher
 
 

--- a/tests/unit/service/test_pool.py
+++ b/tests/unit/service/test_pool.py
@@ -135,7 +135,8 @@ async def test_shutdown_is_idepotent(pool_factory):
     pool = pool_factory()
     await pool.shutdown()  # weird to shutdown before starting, but okay
 
-    await pool.start_working(dispatcher=DispatcherMain(producers=(), pool=pool))
+    dispatcher = DispatcherMain(producers=(), pool=pool, shared=SharedAsyncObjects())
+    await pool.start_working(dispatcher=dispatcher)
 
     await pool.shutdown()
     await pool.shutdown()  # weird to shutdown twice, but... just return


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcherd/issues/9

Fixes https://github.com/ansible/dispatcherd/issues/127

I described in more recent issues - the intent would be to ultimately replace all the existing async tests.

This has a nasty warning:

```
/home/alancoding/venvs/awx/lib64/python3.12/site-packages/psycopg/_connection_base.py:146: ResourceWarning: connection <psycopg.Connection [IDLE] (host=localhost port=55777 user=dispatch database=dispatch_db) at 0x7efbef973710> was deleted while still open. Please use 'with' or '.close()' to close the connection
```

I expect that will be resolved with connection closing @art-tapin did in https://github.com/ansible/dispatcherd/pull/121. Maybe.

Right now this test is slow, but the idea is that we'll start to reuse the fixture between tests and then it will start to go faster. The idea is also to reuse this in AWX and eda-server.