### PR TITLE
Split task-delayer into new module, it is now a task "processor"

### DIFF
--- a/dispatcherd/service/blocker.py
+++ b/dispatcherd/service/blocker.py
@@ -36,7 +36,7 @@ class Blocker(BlockerProtocol):
     def remove_task(self, message: dict) -> None:
         self.blocked_messages.remove(message)
 
-    def process_task(self, message: dict) -> Optional[dict]:
+    async def process_task(self, message: dict) -> Optional[dict]:
         """If task is blocked, it is consumed here and None is returned, if not blocked, return message as-is
 
         Consuming the message may mean discarding it, or it may mean holding it until it is unblocked.

--- a/dispatcherd/service/control_tasks.py
+++ b/dispatcherd/service/control_tasks.py
@@ -43,13 +43,13 @@ async def _find_tasks(dispatcher: DispatcherMain, data: dict, cancel: bool = Fal
                 logger.warning(f'Canceling task in pool queue: {message}')
                 dispatcher.pool.queuer.remove_task(message)
             ret[f'queued-{i}'] = message
-    for i, capsule in enumerate(dispatcher.delayed_messages.copy()):
+    for i, capsule in enumerate(list(dispatcher.delayer)):
         if task_filter_match(capsule.message, data):
             if cancel:
                 uuid = capsule.message.get('uuid', '<unknown>')
                 logger.warning(f'Canceling delayed task (uuid={uuid})')
                 capsule.has_ran = True  # make sure we do not run by accident
-                dispatcher.delayed_messages.remove(capsule)
+                dispatcher.delayer.remove_capsule(capsule)
             ret[f'delayed-{i}'] = capsule.message
     return ret
 

--- a/dispatcherd/service/delayer.py
+++ b/dispatcherd/service/delayer.py
@@ -1,0 +1,84 @@
+import asyncio
+import logging
+import time
+from typing import Any, Callable, Coroutine, Iterator, Optional, cast
+
+from ..protocols import DelayCapsule as DelayCapsuleProtocol
+from ..protocols import Delayer as DelayerProtocol
+from .next_wakeup_runner import HasWakeup, NextWakeupRunner
+
+logger = logging.getLogger(__name__)
+
+
+class DelayCapsule(HasWakeup, DelayCapsuleProtocol):
+    """When a task has a delay, this tracks the delay, as in a time capsule"""
+
+    def __init__(self, delay: float, message: dict) -> None:
+        self.has_ran: bool = False
+        self.received_at = time.monotonic()
+        self.delay = delay
+        self.message = message
+
+    def next_wakeup(self) -> Optional[float]:
+        if self.has_ran is True:
+            return None
+        return self.received_at + self.delay
+
+
+class Delayer(NextWakeupRunner, DelayerProtocol):
+    def __init__(
+        self,
+        process_message_now: Callable[[dict[Any, Any]], Coroutine[Any, Any, tuple[str | None, str | None]]],
+        exit_event: Optional[asyncio.Event] = None,
+    ) -> None:
+        self.delayed_messages: set[DelayCapsuleProtocol] = set()
+        self.shutting_down = False
+        self.process_message_now = process_message_now
+        super().__init__(
+            wakeup_objects=cast(set[HasWakeup], self.delayed_messages),
+            process_object=self.run_delayed_capsule,  # type: ignore[arg-type] # takes capsules, not HasWakeups, which is more specific
+            name='delayed_task_runner',
+            exit_event=exit_event,
+        )
+
+    def __iter__(self) -> Iterator[DelayCapsuleProtocol]:
+        return iter(self.delayed_messages)
+
+    async def shutdown(self) -> None:
+        self.shutting_down = True
+        await super().shutdown()
+        for capsule in self.delayed_messages:
+            logger.warning(f'Abandoning delayed task (due to shutdown) to run in {capsule.delay}, message={capsule.message}')
+        self.delayed_messages = set()
+
+    async def create_delayed_task(self, delay: float, message: dict) -> None:
+        "Called as alternative to sending to worker now, send to worker later"
+        capsule = DelayCapsule(delay, message)
+        logger.info(f'Delaying {capsule.delay} s before running task: {capsule.message}')
+        self.delayed_messages.add(capsule)
+        await self.kick()
+
+    def remove_capsule(self, capsule: DelayCapsuleProtocol) -> None:
+        self.delayed_messages.remove(capsule)
+
+    async def run_delayed_capsule(self, capsule: DelayCapsuleProtocol, /) -> None:
+        """Mark the capsule as having been run for race conditions, remove it from list, call the actual task dispatching method"""
+        capsule.has_ran = True
+        logger.debug(f'Wakeup for delayed task: {capsule.message}')
+        reply_to, payload = await self.process_message_now(capsule.message)
+        if reply_to:
+            logger.warning(f'Can not return reply to channel {reply_to} from delayed tasks, dropping reply:\n{payload}')
+        self.remove_capsule(capsule)
+
+    async def process_task(self, message: dict) -> Optional[dict]:
+        """The general contract for process_task is that we can _consume_ the task and return None
+
+        Here, task consumption means that we store it in the local storage to run later at delayed time.
+        Otherwise, if this is not marked for delayed we hand the task back as return value.
+        """
+        if delay := message.pop('delay', None):
+            # NOTE: control messages with reply should never be delayed, document this for users
+            await self.create_delayed_task(delay, message)
+            return None
+
+        return message

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -496,8 +496,7 @@ class WorkerPool(WorkerPoolProtocol):
 
     async def dispatch_task(self, message: dict) -> None:
         uuid = message.get("uuid", "<unknown>")
-        unblocked_task = self.blocker.process_task(message)
-        if unblocked_task:
+        if unblocked_task := await self.blocker.process_task(message):
             worker = self.queuer.get_worker_or_process_task(unblocked_task)
             if worker:
                 logger.debug(f"Dispatching task (uuid={uuid}) to worker (id={worker.worker_id})")


### PR DESCRIPTION
This stitches together 2 other refactors I already landed:

 - Introduce the generic notion of a task "processor" which can "consume" a task at various points with some implementation differences based on the order in the call stack.
   - The delayer runs early, and has the special ability of running an asyncio task. End result of tasks it consumes is a callback that passes it to the next stage of processing.
   - The blocker avoids running 2 tasks of the same method and call args based on specified `on_duplicate` behavior. End result of consumed tasks is a queue that is consumed in `drain_queue`, or discarded
   - The queuer has access to pool workers, and it places or consumes a task based on current capacity in the pool End result of consumed tasks is, again, a queue consumed by `drain_queue`. End result of non-consumed tasks is placement to worker.
 - Introduce a generic next-run-runner

You can see the whole deal here is that the 1st one, the task-delayer, is both a "processor" and (we'll call it) a "runner". This is not problematic philosophically or otherwise. It's just that I was working on these 2 constructs in parallel and now they are merged so I can do this.