### PR TITLE
Add tests for dropping postgres connection

### DIFF
--- a/dispatcher.yml
+++ b/dispatcher.yml
@@ -11,7 +11,7 @@ service:
 brokers:
   pg_notify:
     config:
-      conninfo: dbname=dispatch_db user=dispatch password=dispatching host=localhost port=55777
+      conninfo: dbname=dispatch_db user=dispatch password=dispatching host=localhost port=55777 application_name=dispatcher_demo_run
     sync_connection_factory: dispatcher.brokers.pg_notify.connection_saver
     # List of channels to listen on
     channels:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 CHANNELS = ['test_channel', 'test_channel2', 'test_channel3']
 
 # Database connection details
-CONNECTION_STRING = "dbname=dispatch_db user=dispatch password=dispatching host=localhost port=55777"
+CONNECTION_STRING = "dbname=dispatch_db user=dispatch password=dispatching host=localhost port=55777 application_name=apg_test_server"
 
 BASIC_CONFIG = {
     "version": 2,
@@ -49,7 +49,8 @@ BASIC_CONFIG = {
 async def aconnection_for_test():
     conn = None
     try:
-        conn = await acreate_connection(conninfo=CONNECTION_STRING, autocommit=True)
+        conn_str = CONNECTION_STRING.replace('application_name=apg_test_server', 'application_name=apg_client')
+        conn = await acreate_connection(conninfo=conn_str, autocommit=True)
 
         # Make sure database is running to avoid deadlocks which can come
         # from using the loop provided by pytest asyncio

--- a/tests/integration/test_disruptions.py
+++ b/tests/integration/test_disruptions.py
@@ -1,0 +1,45 @@
+import asyncio
+
+import pytest
+
+import psycopg
+
+from tests.conftest import CONNECTION_STRING
+
+
+# Change the application_name so that when we run this test we will not kill the connection for the test itself
+THIS_TEST_STR = CONNECTION_STRING.replace('application_name=apg_test_server', 'application_name=do_not_delete_me')
+
+
+@pytest.mark.asyncio
+async def test_sever_pg_connection(apg_dispatcher, pg_message):
+    query = """
+    SELECT pid, usename, application_name, backend_start, state
+    FROM pg_stat_activity
+    WHERE state IS NOT NULL
+      AND application_name = 'apg_test_server'
+    ORDER BY backend_start DESC;
+    """
+    # Asynchronously connect to PostgreSQL using a connection string
+    async with await psycopg.AsyncConnection.connect(THIS_TEST_STR) as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(query)
+            connections = await cur.fetchall()
+
+            pids = []
+            print(f'Found following connections, will kill connections for those pids')
+            for row in connections:
+                pids.append(row[0])
+                print('pid, user, app_name, backend_start, state')
+                print(row)
+
+            assert len(pids) == 1
+
+            for pid in pids:
+                await cur.execute(f"SELECT pg_terminate_backend({pid});")
+
+    assert apg_dispatcher.pool.finished_count == 0
+    clearing_task = asyncio.create_task(apg_dispatcher.pool.events.work_cleared.wait(), name='test_lambda_clear_wait')
+    await pg_message('lambda: "This worked!"')
+    await asyncio.wait_for(clearing_task, timeout=3)
+    assert apg_dispatcher.pool.finished_count == 1


### PR DESCRIPTION
This is created as a compliment to https://github.com/ansible/dispatcherd/pull/126

It is intended to fail, and it does fail.

```
----------------------------------------- Captured log call -----------------------------------------
DEBUG    dispatcher.brokers.pg_notify:pg_notify.py:176 Sent pg_notify message of 22 chars to test_channel
ERROR    asyncio:base_events.py:1826 Exception in callback CallbackHolder.done_callback(<Task finishe...he request.')>)
handle: <Handle CallbackHolder.done_callback(<Task finishe...he request.')>)>
Traceback (most recent call last):
  File "/usr/lib64/python3.12/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/home/alancoding/repos/dispatcher/dispatcher/service/asyncio_tasks.py", line 14, in done_callback
    task.result()
  File "/home/alancoding/repos/dispatcher/dispatcher/producers/brokered.py", line 34, in produce_forever
    async for channel, payload in self.broker.aprocess_notify(connected_callback=self.connected_callback):
  File "/home/alancoding/repos/dispatcher/dispatcher/brokers/pg_notify.py", line 147, in aprocess_notify
    async for notify in connection.notifies():
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/psycopg/connection_async.py", line 365, in notifies
    raise ex.with_traceback(None)
psycopg.OperationalError: consuming input failed: server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
```

For a timeout on the clearing task.

```
>       await asyncio.wait_for(clearing_task, timeout=3)
```

That linked PR should probably fix this.