### PR TITLE
Add more control commands

### DIFF
--- a/dispatcher.yml
+++ b/dispatcher.yml
@@ -33,6 +33,7 @@ producers:
   OnStartProducer:
     task_list:
       'lambda: print("This task runs on startup")': {}
+  ControlProducer:
 publish:
   default_control_broker: socket
   default_broker: pg_notify

--- a/dispatcherd/cli.py
+++ b/dispatcherd/cli.py
@@ -8,6 +8,7 @@ import yaml
 from . import run_service
 from .config import setup
 from .factories import get_control_from_settings
+from .service import control_tasks
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +56,7 @@ def standalone() -> None:
 
 def control() -> None:
     parser = get_parser()
-    parser.add_argument('command', help='The control action to run.')
+    parser.add_argument('command', choices=[cmd for cmd in control_tasks.__all__], help='The control action to run.')
     parser.add_argument(
         '--task',
         type=str,

--- a/dispatcherd/factories.py
+++ b/dispatcherd/factories.py
@@ -46,6 +46,8 @@ def producers_from_settings(settings: LazySettings = global_settings) -> Iterabl
         producer_objects.append(producer)
 
     for producer_cls, producer_kwargs in settings.producers.items():
+        if producer_kwargs is None:
+            producer_kwargs = {}
         producer_objects.append(getattr(producers, producer_cls)(**producer_kwargs))
 
     return producer_objects

--- a/dispatcherd/producers/__init__.py
+++ b/dispatcherd/producers/__init__.py
@@ -1,6 +1,7 @@
 from .base import BaseProducer
 from .brokered import BrokeredProducer
+from .control import ControlProducer
 from .on_start import OnStartProducer
 from .scheduled import ScheduledProducer
 
-__all__ = ['BaseProducer', 'BrokeredProducer', 'ScheduledProducer', 'OnStartProducer']
+__all__ = ['BaseProducer', 'BrokeredProducer', 'ScheduledProducer', 'OnStartProducer', 'ControlProducer']

--- a/dispatcherd/producers/base.py
+++ b/dispatcherd/producers/base.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from ..protocols import Producer
+from ..protocols import Producer as ProducerProtocol
 
 
 class ProducerEvents:
@@ -9,8 +9,11 @@ class ProducerEvents:
         self.recycle_event = asyncio.Event()
 
 
-class BaseProducer(Producer):
+class BaseProducer(ProducerProtocol):
 
     def __init__(self) -> None:
         self.events = ProducerEvents()
         self.produced_count = 0
+
+    def get_status_data(self) -> dict:
+        return {'produced_count': self.produced_count}

--- a/dispatcherd/producers/brokered.py
+++ b/dispatcherd/producers/brokered.py
@@ -29,7 +29,8 @@ class BrokeredProducer(BaseProducer):
         await self.start_producing(self.dispatcher)
 
     def __str__(self) -> str:
-        return f'brokered-producer-{self.broker}'
+        broker_module = self.broker.__module__.rsplit('.', 1)[-1]
+        return f'{broker_module}-producer'
 
     async def start_producing(self, dispatcher: DispatcherMain) -> None:
         self.production_task = asyncio.create_task(self.produce_forever(dispatcher), name=f'{self.broker.__module__}_production')

--- a/dispatcherd/producers/control.py
+++ b/dispatcherd/producers/control.py
@@ -1,0 +1,36 @@
+import asyncio
+import json
+import logging
+from typing import Optional
+
+from ..protocols import DispatcherMain
+from .base import BaseProducer
+
+logger = logging.getLogger(__name__)
+
+
+class ControlProducer(BaseProducer):
+    """Placeholder producer to allow control actions to start tasks
+
+    This must be enabled to start tasks via control actions.
+    Indirectly, this also allows tasks to start other tasks.
+    """
+
+    def __init__(self) -> None:
+        self.dispatcher: Optional[DispatcherMain] = None
+        super().__init__()
+
+    async def start_producing(self, dispatcher: DispatcherMain) -> None:
+        self.dispatcher = dispatcher
+        self.events.ready_event.set()
+
+    async def submit_task(self, data: dict) -> None:
+        assert self.dispatcher is not None
+        await self.dispatcher.process_message(json.dumps(data))
+        self.produced_count += 1
+
+    def all_tasks(self) -> list[asyncio.Task]:
+        return []
+
+    async def shutdown(self) -> None:
+        pass

--- a/dispatcherd/protocols.py
+++ b/dispatcherd/protocols.py
@@ -80,6 +80,10 @@ class Producer(Protocol):
         """Starts tasks which will eventually call DispatcherMain.process_message - how tasks originate in the service"""
         ...
 
+    def get_status_data(self) -> dict:
+        """Data for debugging commands"""
+        ...
+
     async def shutdown(self):
         """Stop producing tasks and clean house, a producer may be shut down independently from the main program"""
         ...
@@ -108,7 +112,7 @@ class PoolWorker(Protocol):
 
     def is_ready(self) -> bool: ...
 
-    def get_data(self) -> dict[str, Any]:
+    def get_status_data(self) -> dict[str, Any]:
         """Used for worker status control-and-reply command"""
         ...
 
@@ -174,6 +178,10 @@ class WorkerPool(Protocol):
         """Called by DispatcherMain after in the normal task lifecycle, pool will try to hand the task to a worker"""
         ...
 
+    def get_status_data(self) -> dict:
+        """Data for debugging commands"""
+        ...
+
     async def shutdown(self) -> None: ...
 
 
@@ -189,6 +197,7 @@ class DispatcherMain(Protocol):
     pool: WorkerPool
     delayed_messages: set
     fd_lock: asyncio.Lock  # Forking and locking may need to be serialized, which this does
+    producers: Iterable[Producer]
 
     async def main(self) -> None:
         """This is the method that runs the service, bring your own event loop"""
@@ -206,4 +215,8 @@ class DispatcherMain(Protocol):
         self, payload: Union[dict, str], producer: Optional[Producer] = None, channel: Optional[str] = None
     ) -> tuple[Optional[str], Optional[str]]:
         """This is called by producers when a new request to run a task comes in"""
+        ...
+
+    def get_status_data(self) -> dict:
+        """Data for debugging commands"""
         ...

--- a/dispatcherd/service/control_tasks.py
+++ b/dispatcherd/service/control_tasks.py
@@ -130,7 +130,7 @@ async def run(dispatcher: DispatcherMain, data: dict) -> dict:
             except Exception as exc:
                 return {'error': str(exc)}
             return {'ack': data}
-    return {'error': 'A ControlBroker producer is not enabled. Add it to the list of producers in the service config to use this.'}
+    return {'error': 'A ControlProducer producer is not enabled. Add it to the list of producers in the service config to use this.'}
 
 
 async def main(dispatcher: DispatcherMain, data: dict) -> dict:

--- a/dispatcherd/service/main.py
+++ b/dispatcherd/service/main.py
@@ -3,7 +3,8 @@ import json
 import logging
 import signal
 import time
-from typing import Iterable, Optional, Union
+from os import getpid
+from typing import Any, Iterable, Optional, Union
 from uuid import uuid4
 
 from ..producers import BrokeredProducer
@@ -67,6 +68,9 @@ class DispatcherMain(DispatcherMainProtocol):
     def receive_signal(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         logger.warning(f"Received exit signal args={args} kwargs={kwargs}")
         self.events.exit_event.set()
+
+    def get_status_data(self) -> dict[str, Any]:
+        return {"received_count": self.received_count, "control_count": self.control_count, "pid": getpid()}
 
     async def wait_for_producers_ready(self) -> None:
         "Returns when all the producers have hit their ready event"

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -118,7 +118,7 @@ class PoolWorker(HasWakeup, PoolWorkerProtocol):
             return  # it's effectively already canceled/not running
         os.kill(self.process.pid, signal.SIGUSR1)  # Use SIGUSR1 instead of SIGTERM
 
-    def get_data(self) -> dict[str, Any]:
+    def get_status_data(self) -> dict[str, Any]:
         return {
             'worker_id': self.worker_id,
             'pid': self.process.pid,
@@ -244,6 +244,13 @@ class WorkerPool(WorkerPoolProtocol):
     @property
     def received_count(self) -> int:
         return self.processed_count + self.queuer.count() + self.blocker.count() + sum(1 for w in self.workers if w.current_task)
+
+    def get_status_data(self) -> dict[str, Any]:
+        return {
+            "next_worker_id": self.next_worker_id,
+            "finished_count": self.finished_count,
+            "canceled_count": self.canceled_count,
+        }
 
     async def start_working(self, dispatcher: DispatcherMain, exit_event: Optional[asyncio.Event] = None) -> None:
         self.dispatcher = dispatcher

--- a/docs/task_options.md
+++ b/docs/task_options.md
@@ -75,6 +75,15 @@ right now it offers:
 
 - `uuid` - the internal id of this task call in dispatcher
 - `worker_id` - the id of the worker running this task
+- `control` - runs a control-and-reply command against its own parent process
+
+Using the `dispatcher.control` interface on the bound object is
+an more efficient alternative to communication over the broker.
+It also allows tasks to dispatch follow-up tasks in the local service.
+
+More complex examples can be found in `tests.data.methods`.
+The `schedules_another_task` example shows how this can be used
+to have a task start another task.
 
 #### Queue
 

--- a/schema.json
+++ b/schema.json
@@ -15,6 +15,7 @@
     }
   },
   "producers": {
+    "ControlProducer": {},
     "ScheduledProducer": {
       "task_schedule": "dict[str, dict[str, typing.Union[int, str]]]"
     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ BASIC_CONFIG = {
             "default_publish_channel": "test_channel",
         }
     },
+    "producers": {"ControlProducer": {}},
     "pool": {"pool_kwargs": {"min_workers": 1, "max_workers": 6}},
 }
 

--- a/tests/data/methods.py
+++ b/tests/data/methods.py
@@ -57,4 +57,10 @@ class RunJob:
 @task(bind=True)
 def prints_running_tasks(binder):
     r = binder.control('running')
-    print(r)
+    print(f'Obtained data on running tasks, result:\n{r}')
+
+
+@task(bind=True)
+def schedules_another_task(binder):
+    r = binder.control('run', data={'task': 'tests.data.methods.print_hello'})
+    print(f'Scheduled another task, result: {r}')

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -187,6 +187,27 @@ async def test_alive_check(apg_dispatcher, pg_control):
 
 
 @pytest.mark.asyncio
+async def test_producers_command(apg_dispatcher, pg_control):
+    producers_list = await asyncio.wait_for(pg_control.acontrol_with_reply('producers', timeout=1), timeout=5)
+    assert len(producers_list) == 1
+    producers = producers_list[0]
+
+    assert 'pg_notify-producer' in producers, producers
+    assert producers['pg_notify-producer']['produced_count'] == apg_dispatcher.producers[0].produced_count, producers
+
+
+@pytest.mark.asyncio
+async def test_status_command(apg_dispatcher, pg_control):
+    status_list = await asyncio.wait_for(pg_control.acontrol_with_reply('status', timeout=1), timeout=5)
+    assert len(status_list) == 1
+    status = status_list[0]
+
+    assert 'producers' in status
+    assert 'running' in status
+    assert 'workers' in status
+
+
+@pytest.mark.asyncio
 async def test_aio_tasks(apg_dispatcher, pg_control):
     aio_tasks_list = await asyncio.wait_for(pg_control.acontrol_with_reply('aio_tasks', timeout=1), timeout=5)
     assert len(aio_tasks_list) == 1


### PR DESCRIPTION
This adds the control commands:
 - producers
 - run
 - status

Only the "producers" actually does much novel, and what it adds isn't much, because we need https://github.com/ansible/dispatcherd/pull/126 to track more meaningful information on the producers.

The "run" command seems silly, but needs https://github.com/ansible/dispatcherd/pull/122, so this _combined with_ that will allow tasks to run control tasks... and one control task can... run other tasks. Put it together, this would allow tasks to run other tasks.

This is extremely demo-able

```
$ dispatcherctl --help
usage: dispatcherctl [-h] [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [--config CONFIG] [--task TASK] [--uuid UUID]
                     [--expected-replies EXPECTED_REPLIES]
                     {running,cancel,alive,aio_tasks,workers,producers,status}

CLI entrypoint for dispatcher, mainly intended for testing.
```

and

```
$ dispatcherctl producers
DEBUG:dispatcher.cli:Configured standard out logging at DEBUG level
INFO:dispatcher.cli:Using config from file /home/alancoding/repos/dispatcher/dispatcher.yml
INFO:awx.main.dispatch.control:control-and-reply producers to None
INFO:dispatcher.brokers.pg_notify:Set up pg_notify listening on channel 'reply_to_0e4410ea_541c_47b7_bb25_aa472084f572'
DEBUG:dispatcher.brokers.pg_notify:Sent pg_notify message of 85 chars to test_channel
DEBUG:dispatcher.brokers.pg_notify:Starting listening for pg_notify notifications
INFO:awx.main.dispatch.control:control-and-reply message returned in 0.07825517654418945 seconds
- BrokeredProducer:
    produced_count: 2
  ControlProducer:
    produced_count: 0
  OnStartProducer:
    produced_count: 1
  ScheduledProducer:
    produced_count: 20
  node_id: demo-server-a
```

And the `dispatcher status` command is nice, but its output is a bit more than I want to paste here.