### PR TITLE
refactor: rename missing refs to dispatcherd

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,9 +15,9 @@ body:
       options:
         - label: I agree to follow this project's [code of conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
           required: true
-        - label: I have checked the [current issues](https://github.com/ansible/dispatcher/issues) for duplicates.
+        - label: I have checked the [current issues](https://github.com/ansible/dispatcherd/issues) for duplicates.
           required: true
-        - label: I understand that dispatcher is open source software provided for free and that I might not receive a timely response.
+        - label: I understand that dispatcherd is open source software provided for free and that I might not receive a timely response.
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,12 +1,12 @@
 blank_issues_enabled: false
 contact_links:
   - name: For debugging help or technical support
-    url: https://github.com/ansible/dispatcher/blob/main/docs/contributing.md#contact
+    url: https://github.com/ansible/dispatcherd/blob/main/docs/contributing.md#contact
     about: For general debugging or technical support please see the linked section of our docs.
 
   - name: 📝 Ansible Code of Conduct
     url: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html
-    about: Dispatcher uses the Ansible Code of Conduct; ❤ Be nice to other members of the community. ☮ Behave.
+    about: Dispatcherd uses the Ansible Code of Conduct; ❤ Be nice to other members of the community. ☮ Behave.
 
   - name: 💼 For Enterprise
     url: https://www.redhat.com/en/technologies/management/ansible

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         Feature Request issues are for **feature requests** only.
-        For debugging help or technical support, please see the [our ways of contact](https://github.com/ansible/dispatcher/blob/main/docs/contributing.md#contact)
+        For debugging help or technical support, please see the [our ways of contact](https://github.com/ansible/dispatcherd/blob/main/docs/contributing.md#contact)
 
   - type: checkboxes
     id: terms
@@ -15,9 +15,9 @@ body:
       options:
         - label: I agree to follow this project's [code of conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
           required: true
-        - label: I have checked the [current issues](https://github.com/ansible/dispatcher/issues) for duplicates.
+        - label: I have checked the [current issues](https://github.com/ansible/dispatcherd/issues) for duplicates.
           required: true
-        - label: I understand that dispatcher is open source software provided for free and that I might not receive a timely response.
+        - label: I understand that dispatcherd is open source software provided for free and that I might not receive a timely response.
           required: true
 
   - type: dropdown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: ${{ matrix.py_version }}
 
-      - name: Install dispatcher
+      - name: Install dispatcherd
         run: pip install -e .[pg_notify]
       - run: make postgres
       - run: pip install pytest pytest-asyncio

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <!-- License Badge -->
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/ansible/dispatcher/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/ansible/dispatcherd/blob/main/LICENSE)
 
 ## Dispatcherd
 
-The dispatcher is a service to run python tasks in subprocesses,
+The dispatcherd is a service to run python tasks in subprocesses,
 designed specifically to work well with pg_notify,
 but intended to be extensible to other message delivery means.
 Its philosophy is to have a limited scope
@@ -19,21 +19,21 @@ Licensed under [Apache Software License 2.0](LICENSE)
 ### Usage
 
 You have a postgres server configured and a python project.
-You will use dispatcher to trigger a background task over pg_notify.
-Both your *background dispatcher service* and your *task publisher* process must have
+You will use dispatcherd to trigger a background task over pg_notify.
+Both your *background dispatcherd service* and your *task publisher* process must have
 python configured so that your task is importable. Instructions are broken into 3 steps:
 
-1. **Library** - Configure dispatcher, mark the python methods you will run with it
-2. **Dispatcher service** - Start your background task service, it will start listening
+1. **Library** - Configure dispatcherd, mark the python methods you will run with it
+2. **dispatcherd service** - Start your background task service, it will start listening
 3. **Publisher** - From some other script, submit tasks to be ran
 
 In the "Manual Demo" section, an runnable example of this is given.
 
 #### Library
 
-The dispatcher `@task()` decorator is used to register tasks.
+The dispatcherd `@task()` decorator is used to register tasks.
 The [tests/data/methods.py](tests/data/methods.py) module defines some
-dispatcher tasks.
+dispatcherd tasks.
 
 The decorator accepts some kwargs (like `queue` below) that will affect task behavior,
 see [docs/task_options.md](docs/task_options.md).
@@ -46,8 +46,8 @@ def print_hello():
     print('hello world!!')
 ```
 
-Configure dispatcher somewhere in your import path or before running the service.
-This tells dispatcher how to submit tasks to be ran.
+Configure dispatcherd somewhere in your import path or before running the service.
+This tells dispatcherd how to submit tasks to be ran.
 
 ```python
 from dispatcherd.config import setup
@@ -73,19 +73,19 @@ see the section [config](docs/config.md) docs.
 The `queue` passed to `@task` needs to match a pg_notify channel in the `config`.
 It is often useful to have different workers listen to different sets of channels.
 
-#### Dispatcher service
+#### dispatcherd service
 
-The dispatcher service needs to be running before you submit tasks.
+The dispatcherd service needs to be running before you submit tasks.
 This does not make any attempts at message durability or confirmation.
 If you submit a task in an outage of the service, it will be dropped.
 
-There are 2 ways to run the dispatcher service:
+There are 2 ways to run the dispatcherd service:
 
 - Importing and running (code snippet below)
 - A CLI entrypoint `dispatcherd` for demo purposes
 
 ```python
-from dispatcher import run_service
+from dispatcherd import run_service
 
 # After the setup() method has been called
 
@@ -101,7 +101,7 @@ from the `test_methods` python module.
 This method does not take any args or kwargs, but if it did, you would
 pass those directly as in, `.delay(*args, **kwargs)`.
 
-The following code will submit `print_hello` to run in the background dispatcher service.
+The following code will submit `print_hello` to run in the background dispatcherd service.
 
 ```python
 from test_methods import print_hello
@@ -149,7 +149,7 @@ Ctl+c to stop that server.
 
 #### Two nodes in background
 
-The following will start up postgres, then start up 2 dispatcher services.
+The following will start up postgres, then start up 2 dispatcherd services.
 It should take a few seconds, mainly waiting for postgres.
 
 ```
@@ -204,7 +204,7 @@ As a part of doing the split, we also want to resolve a number of
 long-standing design and sustainability issues, thus, asyncio.
 For a little more background see [docs/design_notes.md](docs/design_notes.md).
 
-There is documentation of the message formats used by the dispatcher
+There is documentation of the message formats used by the dispatcherd
 in [docs/message_formats.md](docs/message_formats.md). Some of these are internal,
 but some messages are what goes over the user-defined brokers (pg_notify).
 You can trigger tasks using your own "publisher" code as an alternative
@@ -223,7 +223,7 @@ Refer to the [Contributing guide](docs/contributing.md) for further information.
 
 ## Communication
 
-See the [Communication](https://github.com/ansible/dispatcher/blob/main/docs/contributing.md#communication) section of the
+See the [Communication](https://github.com/ansible/dispatcherd/blob/main/docs/contributing.md#communication) section of the
 Contributing guide to find out how to get help and contact us.
 
 For more information about getting in touch, see the
@@ -231,4 +231,4 @@ For more information about getting in touch, see the
 
 ## Credits
 
-Dispatcher is sponsored by [Red Hat, Inc](https://www.redhat.com).
+Dispatcherd is sponsored by [Red Hat, Inc](https://www.redhat.com).

--- a/dispatcherd/__init__.py
+++ b/dispatcherd/__init__.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 def run_service() -> None:
     """
-    Runs dispatcher task service (runs tasks due to messages from brokers and other local producers)
+    Runs dispatcherd task service (runs tasks due to messages from brokers and other local producers)
     Before calling this you need to configure by calling dispatcherd.config.setup
     """
     loop = asyncio.get_event_loop()
@@ -16,6 +16,6 @@ def run_service() -> None:
     try:
         loop.run_until_complete(dispatcher.main())
     except KeyboardInterrupt:
-        logger.info('Dispatcher stopped by KeyboardInterrupt')
+        logger.info('Dispatcherd stopped by KeyboardInterrupt')
     finally:
         loop.close()

--- a/dispatcherd/brokers/pg_notify.py
+++ b/dispatcherd/brokers/pg_notify.py
@@ -13,7 +13,7 @@ from ..utils import resolve_callable
 logger = logging.getLogger(__name__)
 
 
-"""This module exists under the theory that dispatcher messaging should be swappable
+"""This module exists under the theory that dispatcherd messaging should be swappable
 
 to different message busses eventually.
 That means that the main code should never import psycopg.
@@ -332,7 +332,7 @@ def connection_saver(**config) -> psycopg.Connection:  # type: ignore[no-untyped
     This mimics the behavior of Django for tests and demos
     Philosophically, this is used by an application that uses an ORM,
     or otherwise has its own connection management logic.
-    Dispatcher does not manage connections, so this a simulation of that.
+    Dispatcherd does not manage connections, so this a simulation of that.
 
     Uses a thread lock to ensure thread safety.
     """
@@ -348,7 +348,7 @@ async def async_connection_saver(**config) -> psycopg.AsyncConnection:  # type: 
     This mimics the behavior of Django for tests and demos
     Philosophically, this is used by an application that uses an ORM,
     or otherwise has its own connection management logic.
-    Dispatcher does not manage connections, so this a simulation of that.
+    Dispatcherd does not manage connections, so this a simulation of that.
 
     Uses a thread lock to ensure thread safety.
     """

--- a/dispatcherd/cli.py
+++ b/dispatcherd/cli.py
@@ -16,7 +16,7 @@ DEFAULT_CONFIG_FILE = 'dispatcher.yml'
 
 
 def get_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="CLI entrypoint for dispatcher, mainly intended for testing.")
+    parser = argparse.ArgumentParser(description="CLI entrypoint for dispatcherd, mainly intended for testing.")
     parser.add_argument(
         '--log-level',
         type=str,
@@ -28,7 +28,7 @@ def get_parser() -> argparse.ArgumentParser:
         '--config',
         type=os.path.abspath,
         default=DEFAULT_CONFIG_FILE,
-        help='Path to dispatcher config.',
+        help='Path to dispatcherd config.',
     )
     return parser
 

--- a/dispatcherd/config.py
+++ b/dispatcherd/config.py
@@ -40,7 +40,7 @@ def settings_from_file(path: str) -> DispatcherSettings:
 def settings_from_env() -> DispatcherSettings:
     if file_path := os.getenv('DISPATCHERD_CONFIG_FILE'):
         return settings_from_file(file_path)
-    raise RuntimeError('Dispatcher not configured, set DISPATCHERD_CONFIG_FILE or call dispatcherd.config.setup')
+    raise RuntimeError('Dispatcherd not configured, set DISPATCHERD_CONFIG_FILE or call dispatcherd.config.setup')
 
 
 class LazySettings:

--- a/dispatcherd/protocols.py
+++ b/dispatcherd/protocols.py
@@ -21,7 +21,7 @@ class Broker(Protocol):
     async def aprocess_notify(
         self, connected_callback: Optional[Optional[Callable[[], Coroutine[Any, Any, None]]]] = None
     ) -> AsyncGenerator[tuple[str, str], None]:
-        """The generator of messages from the broker for the dispatcher service
+        """The generator of messages from the broker for the dispatcherd service
 
         The producer iterates this to produce tasks.
         This uses the async connection of the broker.
@@ -29,7 +29,7 @@ class Broker(Protocol):
         yield ('', '')  # yield affects CPython type https://github.com/python/mypy/pull/18422
 
     async def apublish_message(self, channel: Optional[str] = None, message: str = '') -> None:
-        """Asynchronously send a message to the broker, used by dispatcher service for reply messages"""
+        """Asynchronously send a message to the broker, used by dispatcherd service for reply messages"""
         ...
 
     async def aclose(self) -> None:
@@ -177,7 +177,7 @@ class WorkerPool(Protocol):
 
 class DispatcherMain(Protocol):
     """
-    Describes the primary dispatcher interface.
+    Describes the primary dispatcherd interface.
 
     This interface defines the contract for the overall task dispatching service,
     including coordinating task processing, managing the worker pool, and

--- a/dispatcherd/registry.py
+++ b/dispatcherd/registry.py
@@ -106,7 +106,7 @@ class UnregisteredMethod(DispatcherMethod):
     def __init__(self, task: str) -> None:
         fn = resolve_callable(task)
         if fn is None:
-            raise ImportError(f'Dispatcher could not import provided identifier: {task}')
+            raise ImportError(f'Dispatcherd could not import provided identifier: {task}')
         super().__init__(fn)
 
 

--- a/dispatcherd/service/blocker.py
+++ b/dispatcherd/service/blocker.py
@@ -93,4 +93,4 @@ class Blocker(BlockerProtocol):
         self.shutting_down = True
         if self.blocked_messages:
             uuids = [message.get('uuid', '<unknown>') for message in self.blocked_messages]
-            logger.error(f'Dispatcher shut down with blocked work, uuids: {uuids}')
+            logger.error(f'Dispatcherd shut down with blocked work, uuids: {uuids}')

--- a/dispatcherd/service/main.py
+++ b/dispatcherd/service/main.py
@@ -53,7 +53,7 @@ class DispatcherMain(DispatcherMainProtocol):
         self.pool = pool
         self.producers = producers
 
-        # Identifer for this instance of the dispatcher service, sent in reply messages
+        # Identifer for this instance of the dispatcherd service, sent in reply messages
         if node_id:
             self.node_id = node_id
         else:
@@ -255,7 +255,7 @@ class DispatcherMain(DispatcherMainProtocol):
         try:
             await self.start_working()
 
-            logger.info(f'Dispatcher node_id={self.node_id} running forever, or until shutdown command')
+            logger.info(f'Dispatcherd node_id={self.node_id} running forever, or until shutdown command')
 
             while True:
                 await self.main_loop_wait()
@@ -270,4 +270,4 @@ class DispatcherMain(DispatcherMainProtocol):
 
             await self.cancel_tasks()
 
-        logger.debug('Dispatcher loop fully completed')
+        logger.debug('Dispatcherd loop fully completed')

--- a/dispatcherd/service/queuer.py
+++ b/dispatcherd/service/queuer.py
@@ -50,4 +50,4 @@ class Queuer(QueuerProtocol):
         """Just write log messages about what backed up work we will lose"""
         if self.queued_messages:
             uuids = [message.get('uuid', '<unknown>') for message in self.queued_messages]
-            logger.error(f'Dispatcher shut down with queued work, uuids: {uuids}')
+            logger.error(f'Dispatcherd shut down with queued work, uuids: {uuids}')

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,4 +1,4 @@
-## Dispatcher Configuration
+## dispatcherd Configuration
 
 Why is configuration needed? Consider doing this, which uses the demo content:
 
@@ -8,9 +8,9 @@ PYTHONPATH=$PYTHONPATH:tools/ python -c "from tools.test_methods import sleep_fu
 
 This will result in an error:
 
-> Dispatcher not configured, set DISPATCHERD_CONFIG_FILE or call dispatcher.config.setup
+> Dispatcherd not configured, set DISPATCHERD_CONFIG_FILE or call dispatcherd.config.setup
 
-This errors because dispatcher does not know how to connect to a message broker.
+This errors because dispatcherd does not know how to connect to a message broker.
 For the demo, that would be the postgres host, user, password, etc.,
 as well as the pg_notify channel to send the message to.
 
@@ -23,7 +23,7 @@ The demo runs using the `dispatcher.yml` config file at the top-level of this re
 You can do the same thing in python by:
 
 ```python
-from dispatcher.config import setup
+from dispatcherd.config import setup
 
 setup(file_path='dispatcher.yml')
 ```
@@ -54,7 +54,7 @@ At the top-level, config is broken down by either the process that uses that sec
 or brokers, which is a shared resources used by multiple processes.
 
 At the level below that, the config gives instructions for creating python objects.
-The module `dispatcher.factories` has the task of creating those objects from settings.
+The module `dispatcherd.factories` has the task of creating those objects from settings.
 The design goal is to have a little possible divergence from the settings structure
 and the class structure in the code.
 
@@ -98,7 +98,7 @@ Right now the only broker available is pg_notify.
 
 The sub-options become python `kwargs` passed to the broker class `Broker`.
 For now, you will just have to read the code to see what those options are
-at [dispatcherd.brokers.pg_notify](dispatcher/brokers/pg_notify.py).
+at [dispatcherd.brokers.pg_notify](dispatcherd/brokers/pg_notify.py).
 
 The broker classes have methods that allow for submitting messages
 and reading messages.
@@ -108,7 +108,7 @@ and reading messages.
 This configures the background task service.
 
 The `pool_kwargs` options will correspond to the `WorkerPool` class
-[dispatcherd.pool](dispatcher/pool.py).
+[dispatcherd.pool](dispatcherd/pool.py).
 Process management options will be added to this section later.
 
 These options are mainly concerned with worker
@@ -117,11 +117,11 @@ like worker count, etc.
 
 #### Producers
 
-These are "producers of tasks" in the dispatcher service.
+These are "producers of tasks" in the dispatcherd service.
 
 For every listed broker, a `BrokeredProducer` is automatically
 created. That means that tasks may be produced from the messaging
-system that the dispatcher service is listening to.
+system that the dispatcherd service is listening to.
 
 The others are:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,7 +7,7 @@ You can contribute in many ways:
 
 ## Report Bugs or Request Features
 
-Report bugs or request new features at <https://github.com/ansible/dispatcher/issues>
+Report bugs or request new features at <https://github.com/ansible/dispatcherd/issues>
 
 If you are reporting a bug, please fill the form and try to include:
 

--- a/docs/design_notes.md
+++ b/docs/design_notes.md
@@ -1,6 +1,6 @@
 ## Design Notes
 
-Many of the specific choices made in the dispatcher design are to enable pg_notify use.
+Many of the specific choices made in the dispatcherd design are to enable pg_notify use.
 The advantage of using pg_notify is that you get an extremely simple topology.
 Imagine a web and a task runner service, invoked separately, using postgres.
 
@@ -15,7 +15,7 @@ A-->C
 B-->C
 ```
 
-However, pg_notify is not a true queue, and this drives the design of the dispatcher,
+However, pg_notify is not a true queue, and this drives the design of the dispatcherd,
 having its main process listening for messages and farming the work out to worker subprocesses.
 
 This helps with pg_notify use, but still doesn't solve all the problems,
@@ -81,7 +81,6 @@ This is also done in this library, and diverges from AWX practice.
 In AWX dispatcher, a full queue may put messages into individual worker IPCs.
 This caused bad results, like delaying tasks due to long-running jobs,
 while the pool had many other workers free up in the mean time.
-
 
 ### Worker Task Cancelation Signals
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ include = ["dispatcherd*"]
 include-package-data = true # Ensures package data is included
 
 [tool.setuptools.package-data]
-"dispatcher" = ["LICENSE", "README.md"]
+"dispatcherd" = ["LICENSE", "README.md"]
 
 # You need psycopg, but this will not help you to install it
 

--- a/run_demo.py
+++ b/run_demo.py
@@ -93,7 +93,7 @@ def main():
     print('')
     print('running tests.data.methods.sleep_function with a delay')
     print('     10 second delay task')
-    # NOTE: this task will error unless you run the dispatcher itself with it in the PYTHONPATH, which is intended
+    # NOTE: this task will error unless you run the dispatcherd itself with it in the PYTHONPATH, which is intended
     sleep_function.apply_async(
         args=[3],  # sleep 3 seconds
         delay=10,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -11,7 +11,7 @@ def test_settings_reference_unconfigured():
     settings = LazySettings()
     with pytest.raises(Exception) as exc:
         settings.brokers
-    assert 'Dispatcher not configured' in str(exc)
+    assert 'Dispatcherd not configured' in str(exc)
 
 
 def test_configured_settings():


### PR DESCRIPTION
Follow up https://github.com/ansible/dispatcherd/pull/134
Rename missing references to `dispatcherd`, mostly docs, logging msgs and links. 