### PR TITLE
Fix demo build by installing git

### DIFF
--- a/tools/demo/Dockerfile
+++ b/tools/demo/Dockerfile
@@ -8,6 +8,9 @@ RUN python3 -m venv /dispatcherd/venv
 
 RUN echo $pwd
 
+# Git is necessary because of setuptools-scm
+RUN apk add --no-cache git
+
 COPY . ./src
 
 RUN /dispatcherd/venv/bin/pip3 install -e ./src[pg_notify] --verbose


### PR DESCRIPTION
Dynamic versioning added in https://github.com/ansible/dispatcherd/pull/135 requires git, or else the `pip install` command will error. This adds the git install so that the demo docker-compose can build again.