### PR TITLE
Exclude stopping status from process reaper

### DIFF
--- a/dispatcherd/protocols.py
+++ b/dispatcherd/protocols.py
@@ -110,7 +110,14 @@ class PoolWorker(Protocol):
 
     async def start_task(self, message: dict) -> None: ...
 
+    @property
     def is_ready(self) -> bool: ...
+
+    @property
+    def counts_for_capacity(self) -> bool: ...
+
+    @property
+    def expected_alive(self) -> bool: ...
 
     def get_status_data(self) -> dict[str, Any]:
         """Used for worker status control-and-reply command"""

--- a/dispatcherd/service/queuer.py
+++ b/dispatcherd/service/queuer.py
@@ -20,7 +20,7 @@ class Queuer(QueuerProtocol):
 
     def get_free_worker(self) -> Optional[PoolWorker]:
         for candidate_worker in self.workers:
-            if (not candidate_worker.current_task) and candidate_worker.is_ready():
+            if (not candidate_worker.current_task) and candidate_worker.is_ready:
                 return candidate_worker
         return None
 


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcherd/issues/146

This really just adds "stopping" to what is considered in the now `expected_alive` status list. This may not be obvious. I had to do:

```
>>> a = set(['initialized', 'spawned', 'starting', 'ready', 'stopping', 'exited', 'error', 'retired'])
>>> 
>>> a - set(['retired', 'error', 'exited', 'initialized', 'stopping', 'spawned'])
{'starting', 'ready'}
```

So instead of checking `status not in`, I changed it to just a `status in` check, because there are fewer status items to include, and it becomes more clear.

Also made the `@property` pattern a little more consistent.