### PR TITLE
Add names to all asyncio tasks

### DIFF
--- a/dispatcherd/brokers/socket.py
+++ b/dispatcherd/brokers/socket.py
@@ -77,6 +77,9 @@ class Broker(BrokerProtocol):
         client = Client(self.client_ct, reader, writer)
         self.clients[self.client_ct] = client
         self.client_ct += 1
+        current_task = asyncio.current_task()
+        if current_task is not None:
+            current_task.set_name(f'socket_client_task_{client.client_id}')
         logger.info(f'Socket client_id={client.client_id} is connected')
 
         try:

--- a/dispatcherd/brokers/socket.py
+++ b/dispatcherd/brokers/socket.py
@@ -6,6 +6,7 @@ import socket
 from typing import Any, AsyncGenerator, Callable, Coroutine, Iterator, Optional, Union
 
 from ..protocols import Broker as BrokerProtocol
+from ..service.asyncio_tasks import named_wait
 
 logger = logging.getLogger(__name__)
 
@@ -73,14 +74,6 @@ class Broker(BrokerProtocol):
     def __str__(self) -> str:
         return f'socket-broker-{self.socket_path}'
 
-    async def _named_wait(self, event: asyncio.Event, id: int) -> None:
-        """Add a name to waiting task so it is visible via debugging commands"""
-        current_task = asyncio.current_task()
-        if current_task:
-            current_task.set_name(f'internal_wait_for_client_{id}')
-
-        await event.wait()
-
     async def _add_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         client = Client(self.client_ct, reader, writer)
         self.clients[self.client_ct] = client
@@ -100,7 +93,7 @@ class Broker(BrokerProtocol):
                 await self.incoming_queue.put((client.client_id, message))
                 # Wait for caller to potentially fill a reply queue
                 # this should realistically never take more than a trivial amount of time
-                await asyncio.wait_for(self._named_wait(client.yield_clear, client.client_id), timeout=2)
+                await asyncio.wait_for(named_wait(client.yield_clear, f'internal_wait_for_client_{client.client_id}'), timeout=2)
                 client.yield_clear.clear()
                 await client.send_replies()
         except asyncio.TimeoutError:

--- a/dispatcherd/producers/base.py
+++ b/dispatcherd/producers/base.py
@@ -10,6 +10,7 @@ class ProducerEvents:
 
 
 class BaseProducer(ProducerProtocol):
+    can_recycle: bool = False
 
     def __init__(self) -> None:
         self.events = ProducerEvents()

--- a/dispatcherd/producers/brokered.py
+++ b/dispatcherd/producers/brokered.py
@@ -9,6 +9,8 @@ logger = logging.getLogger(__name__)
 
 
 class BrokeredProducer(BaseProducer):
+    can_recycle = True
+
     def __init__(self, broker: Broker) -> None:
         self.production_task: Optional[asyncio.Task] = None
         self.broker = broker

--- a/dispatcherd/protocols.py
+++ b/dispatcherd/protocols.py
@@ -75,6 +75,7 @@ class Producer(Protocol):
     """
 
     events: ProducerEvents
+    can_recycle: bool
 
     async def start_producing(self, dispatcher: 'DispatcherMain') -> None:
         """Starts tasks which will eventually call DispatcherMain.process_message - how tasks originate in the service"""

--- a/dispatcherd/service/asyncio_tasks.py
+++ b/dispatcherd/service/asyncio_tasks.py
@@ -56,3 +56,12 @@ async def wait_for_any(events: Iterable[asyncio.Event], names: Optional[Iterable
             return i
 
     raise RuntimeError('Internal error - could done find any tasks that are done')
+
+
+async def named_wait(event: asyncio.Event, name: str) -> None:
+    """Add a name to waiting task so it is visible via debugging commands"""
+    current_task = asyncio.current_task()
+    if current_task:
+        current_task.set_name(f'internal_wait_for_client_{id}')
+
+    await event.wait()

--- a/dispatcherd/service/asyncio_tasks.py
+++ b/dispatcherd/service/asyncio_tasks.py
@@ -62,6 +62,6 @@ async def named_wait(event: asyncio.Event, name: str) -> None:
     """Add a name to waiting task so it is visible via debugging commands"""
     current_task = asyncio.current_task()
     if current_task:
-        current_task.set_name(f'internal_wait_for_client_{id}')
+        current_task.set_name(name)
 
     await event.wait()

--- a/dispatcherd/service/asyncio_tasks.py
+++ b/dispatcherd/service/asyncio_tasks.py
@@ -36,12 +36,15 @@ def ensure_fatal(task: asyncio.Task, exit_event: Optional[asyncio.Event] = None)
     return task  # nicety so this can be used as a wrapper
 
 
-async def wait_for_any(events: Iterable[asyncio.Event]) -> int:
+async def wait_for_any(events: Iterable[asyncio.Event], names: Optional[Iterable[str]] = None) -> int:
     """
     Wait for a list of events. If any of the events gets set, this function
     will return
     """
-    tasks = [asyncio.create_task(event.wait()) for event in events]
+    if names:
+        tasks = [asyncio.create_task(event.wait(), name=task_name) for (event, task_name) in zip(events, names)]
+    else:
+        tasks = [asyncio.create_task(event.wait()) for event in events]
     done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
     for task in pending:
         task.cancel()

--- a/dispatcherd/service/next_wakeup_runner.py
+++ b/dispatcherd/service/next_wakeup_runner.py
@@ -4,7 +4,7 @@ import time
 from abc import abstractmethod
 from typing import Any, Callable, Coroutine, Iterable, Optional
 
-from .asyncio_tasks import ensure_fatal
+from .asyncio_tasks import ensure_fatal, named_wait
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +92,7 @@ class NextWakeupRunner:
                 delta = 0.1
 
             try:
-                await asyncio.wait_for(self.kick_event.wait(), timeout=delta)
+                await asyncio.wait_for(named_wait(self.kick_event, f'{self.name}_kick_event_wait'), timeout=delta)
             except asyncio.TimeoutError:
                 pass  # intended mechanism to hit the next schedule
             except asyncio.CancelledError:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,9 @@
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def python312():
+    if sys.version_info < (3, 12):
+        pytest.skip("test requires python 3.12")

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -297,7 +297,7 @@ async def test_scale_up(apg_dispatcher, test_settings):
 
 
 @pytest.mark.asyncio
-async def test_tasks_are_named(apg_dispatcher):
+async def test_tasks_are_named(apg_dispatcher, python312):
     wait_task = asyncio.create_task(apg_dispatcher.main_loop_wait(), name='this_is_for_test')
 
     current_task = asyncio.current_task()

--- a/tests/integration/test_socket_use.py
+++ b/tests/integration/test_socket_use.py
@@ -88,7 +88,7 @@ async def test_simple_control_and_reply(asock_dispatcher, sock_control):
 
 
 @pytest.mark.asyncio
-async def test_socket_tasks_are_named(asock_dispatcher, sock_control):
+async def test_socket_tasks_are_named(asock_dispatcher, sock_control, python312):
     loop = asyncio.get_event_loop()
 
     def aio_tasks_cmd():

--- a/tests/integration/test_socket_use.py
+++ b/tests/integration/test_socket_use.py
@@ -104,17 +104,3 @@ async def test_socket_tasks_are_named(asock_dispatcher, sock_control):
         if task_name == current_task_name:
             continue
         assert not task_name.startswith('Task-'), task_stuff['stack']
-
-    # import pdb; pdb.set_trace()
-
-    # wait_task = asyncio.create_task(asock_dispatcher.main_loop_wait(), name='this_is_for_test')
-
-    # current_task = asyncio.current_task()
-    # for task in asyncio.all_tasks():
-    #     if task is current_task:
-    #         continue
-    #     task_name = task.get_name()
-    #     assert not task_name.startswith('Task-'), _stack_from_task(task)
-
-    # apg_dispatcher.events.exit_event.set()
-    # await wait_task

--- a/tests/integration/test_socket_use.py
+++ b/tests/integration/test_socket_use.py
@@ -10,6 +10,7 @@ from dispatcherd.config import DispatcherSettings
 from dispatcherd.control import Control
 from dispatcherd.factories import from_settings, get_control_from_settings, get_publisher_from_settings
 from dispatcherd.protocols import DispatcherMain
+from dispatcherd.service.control_tasks import _stack_from_task
 
 logger = logging.getLogger(__name__)
 
@@ -84,3 +85,36 @@ async def test_simple_control_and_reply(asock_dispatcher, sock_control):
     data = alive[0]
 
     assert data['node_id'] == 'socket-test-server'
+
+
+@pytest.mark.asyncio
+async def test_socket_tasks_are_named(asock_dispatcher, sock_control):
+    loop = asyncio.get_event_loop()
+
+    def aio_tasks_cmd():
+        return sock_control.control_with_reply('aio_tasks')
+
+    aio_tasks = await loop.run_in_executor(None, aio_tasks_cmd)
+
+    current_task_name = asyncio.current_task().get_name()
+
+    assert len(aio_tasks) == 1
+    data = aio_tasks[0]
+    for task_name, task_stuff in data.items():
+        if task_name == current_task_name:
+            continue
+        assert not task_name.startswith('Task-'), task_stuff['stack']
+
+    # import pdb; pdb.set_trace()
+
+    # wait_task = asyncio.create_task(asock_dispatcher.main_loop_wait(), name='this_is_for_test')
+
+    # current_task = asyncio.current_task()
+    # for task in asyncio.all_tasks():
+    #     if task is current_task:
+    #         continue
+    #     task_name = task.get_name()
+    #     assert not task_name.startswith('Task-'), _stack_from_task(task)
+
+    # apg_dispatcher.events.exit_event.set()
+    # await wait_task


### PR DESCRIPTION
I was debugging AWX and had stuff like this:

https://gist.github.com/AlanCoding/36e2256fb74ecc6556d6f5f384bd4974

```
    Task-215555:
      done: false
      stack: "Stack for <Task pending name='Task-215555' coro=<Event.wait() running\
        \ at /usr/lib64/python3.11/asyncio/locks.py:213> wait_for=<Future pending\
        \ cb=[Task.task_wakeup()]> cb=[_wait.<locals>._on_completion() at /usr/lib64/python3.11/asyncio/tasks.py:519]>\
        \ (most recent call last):\n  File \"/usr/lib64/python3.11/asyncio/locks.py\"\
        , line 213, in wait\n    await fut\n"
```

This made me very nervous. Does this list contain _too_ many tasks? Did a task go rogue and fail to get cleaned up? If that happened, how could I know?!

It seems the only option is to identify the purpose of all tasks, and identify them with a name that hints at this purpose (which someone could search the code base for).

To accomplish this, though, it's hard to add complete coverage. I had to add 2 tests to get the socket & pg_notify production tested. Manually, this gives everything I wanted to get:

```
- ScheduledProducer:
    done: false
    stack: "Stack for <Task pending name='ScheduledProducer' coro=<NextWakeupRunner.background_task()\
      \ running at /home/alancoding/repos/dispatcher/dispatcherd/service/next_wakeup_runner.py:95>\
      \ wait_for=<Future pending cb=[Task.task_wakeup()]> cb=[CallbackHolder.done_callback(),\
      \ CallbackHolder.done_callback()]> (most recent call last):\n  File \"/home/alancoding/repos/dispatcher/dispatcherd/service/next_wakeup_runner.py\"\
      , line 95, in background_task\n    await asyncio.wait_for(self.kick_event.wait(),\
      \ timeout=delta)\n"
  dispatcherd.brokers.pg_notify_production:
    done: false
    stack: "Stack for <Task pending name='dispatcherd.brokers.pg_notify_production'\
      \ coro=<BrokeredProducer.produce_forever() running at /home/alancoding/repos/dispatcher/dispatcherd/producers/brokered.py:53>\
      \ wait_for=<Future pending cb=[Task.task_wakeup()]> cb=[CallbackHolder.done_callback()]>\
      \ (most recent call last):\n  File \"/home/alancoding/repos/dispatcher/dispatcherd/producers/brokered.py\"\
      , line 53, in produce_forever\n    async for channel, payload in self.broker.aprocess_notify(connected_callback=self.connected_callback):\n"
  dispatcherd.brokers.socket_production:
    done: false
    stack: "Stack for <Task pending name='dispatcherd.brokers.socket_production' coro=<BrokeredProducer.produce_forever()\
      \ running at /home/alancoding/repos/dispatcher/dispatcherd/producers/brokered.py:55>\
      \ cb=[CallbackHolder.done_callback()]> (most recent call last):\n  File \"/home/alancoding/repos/dispatcher/dispatcherd/__init__.py\"\
      , line 17, in run_service\n    loop.run_until_complete(dispatcher.main())\n\
      \  File \"/usr/lib64/python3.12/asyncio/base_events.py\", line 678, in run_until_complete\n\
      \    self.run_forever()\n  File \"/usr/lib64/python3.12/asyncio/base_events.py\"\
      , line 645, in run_forever\n    self._run_once()\n  File \"/usr/lib64/python3.12/asyncio/base_events.py\"\
      , line 1999, in _run_once\n    handle._run()\n  File \"/usr/lib64/python3.12/asyncio/events.py\"\
      , line 88, in _run\n    self._context.run(self._callback, *self._args)\n  File\
      \ \"/home/alancoding/repos/dispatcher/dispatcherd/producers/brokered.py\", line\
      \ 55, in produce_forever\n    reply_to, reply_payload = await dispatcher.process_message(payload,\
      \ producer=self, channel=str(channel))\n"
  dispatcherd_service_main:
    done: false
    stack: "Stack for <Task pending name='dispatcherd_service_main' coro=<DispatcherMain.main()\
      \ running at /home/alancoding/repos/dispatcher/dispatcherd/service/main.py:278>\
      \ wait_for=<Future pending cb=[Task.task_wakeup()]> cb=[_run_until_complete_cb()\
      \ at /usr/lib64/python3.12/asyncio/base_events.py:181]> (most recent call last):\n\
      \  File \"/home/alancoding/repos/dispatcher/dispatcherd/service/main.py\", line\
      \ 278, in main\n    await self.main_loop_wait()\n"
  exit_event_wait:
    done: false
    stack: "Stack for <Task pending name='exit_event_wait' coro=<Event.wait() running\
      \ at /usr/lib64/python3.12/asyncio/locks.py:212> wait_for=<Future pending cb=[Task.task_wakeup()]>\
      \ cb=[_wait.<locals>._on_completion() at /usr/lib64/python3.12/asyncio/tasks.py:534]>\
      \ (most recent call last):\n  File \"/usr/lib64/python3.12/asyncio/locks.py\"\
      , line 212, in wait\n    await fut\n"
  management_task:
    done: false
    stack: "Stack for <Task pending name='management_task' coro=<WorkerPool.manage_workers()\
      \ running at /home/alancoding/repos/dispatcher/dispatcherd/service/pool.py:395>\
      \ wait_for=<Future pending cb=[Task.task_wakeup()]> cb=[CallbackHolder.done_callback()]>\
      \ (most recent call last):\n  File \"/home/alancoding/repos/dispatcher/dispatcherd/service/pool.py\"\
      , line 395, in manage_workers\n    await asyncio.wait_for(self.events.management_event.wait(),\
      \ timeout=self.scaledown_interval)\n"
  node_id: demo-server-a
  pg_notify-producer_recycle_event_wait:
    done: false
    stack: "Stack for <Task pending name='pg_notify-producer_recycle_event_wait' coro=<Event.wait()\
      \ running at /usr/lib64/python3.12/asyncio/locks.py:212> wait_for=<Future pending\
      \ cb=[Task.task_wakeup()]> cb=[_wait.<locals>._on_completion() at /usr/lib64/python3.12/asyncio/tasks.py:534]>\
      \ (most recent call last):\n  File \"/usr/lib64/python3.12/asyncio/locks.py\"\
      , line 212, in wait\n    await fut\n"
  results_task:
    done: false
    stack: "Stack for <Task pending name='results_task' coro=<WorkerPool.read_results_forever()\
      \ running at /home/alancoding/repos/dispatcher/dispatcherd/service/pool.py:576>\
      \ wait_for=<Future pending cb=[_chain_future.<locals>._call_check_cancel() at\
      \ /usr/lib64/python3.12/asyncio/futures.py:389, Task.task_wakeup()]> cb=[CallbackHolder.done_callback()]>\
      \ (most recent call last):\n  File \"/home/alancoding/repos/dispatcher/dispatcherd/service/pool.py\"\
      , line 576, in read_results_forever\n    message = await self.process_manager.read_finished()\n"
  socket-producer_recycle_event_wait:
    done: false
    stack: "Stack for <Task pending name='socket-producer_recycle_event_wait' coro=<Event.wait()\
      \ running at /usr/lib64/python3.12/asyncio/locks.py:212> wait_for=<Future pending\
      \ cb=[Task.task_wakeup()]> cb=[_wait.<locals>._on_completion() at /usr/lib64/python3.12/asyncio/tasks.py:534]>\
      \ (most recent call last):\n  File \"/usr/lib64/python3.12/asyncio/locks.py\"\
      , line 212, in wait\n    await fut\n"
  socket_client_task_1:
    done: false
    stack: "Stack for <Task pending name='socket_client_task_1' coro=<Broker._add_client()\
      \ running at /home/alancoding/repos/dispatcher/dispatcherd/brokers/socket.py:95>\
      \ wait_for=<Future pending cb=[Task.task_wakeup()]> cb=[StreamReaderProtocol.connection_made.<locals>.callback()\
      \ at /usr/lib64/python3.12/asyncio/streams.py:248]> (most recent call last):\n\
      \  File \"/home/alancoding/repos/dispatcher/dispatcherd/brokers/socket.py\"\
      , line 95, in _add_client\n    await asyncio.wait_for(client.yield_clear.wait(),\
      \ timeout=2)\n"
```