### PR TITLE
Use a shared set of asyncio objects for code flow control

### DIFF
--- a/dispatcherd/config.py
+++ b/dispatcherd/config.py
@@ -76,3 +76,8 @@ def temporary_settings(config):
         yield settings
     finally:
         settings._wrapped = prior_settings
+
+
+def is_setup(for_settings: LazySettings = settings) -> bool:
+    """Tells whether dispatcherd has been configured"""
+    return for_settings._wrapped is None

--- a/dispatcherd/factories.py
+++ b/dispatcherd/factories.py
@@ -55,9 +55,11 @@ def producers_from_settings(shared: SharedAsyncObjects, settings: LazySettings =
 
     for producer_cls, producer_kwargs in settings.producers.items():
         if producer_kwargs is None:
-            producer_kwargs = {}
-        producer_kwargs['shared'] = shared
-        producer_objects.append(getattr(producers, producer_cls)(**producer_kwargs))
+            create_kwargs = {}
+        else:
+            create_kwargs = producer_kwargs.copy()
+        create_kwargs['shared'] = shared
+        producer_objects.append(getattr(producers, producer_cls)(**create_kwargs))
 
     return producer_objects
 

--- a/dispatcherd/producers/brokered.py
+++ b/dispatcherd/producers/brokered.py
@@ -3,6 +3,7 @@ import logging
 from typing import Iterable, Optional, Union
 
 from ..protocols import Broker, DispatcherMain
+from ..protocols import SharedAsyncObjects as SharedAsyncObjectsProtocol
 from .base import BaseProducer
 
 logger = logging.getLogger(__name__)
@@ -11,7 +12,7 @@ logger = logging.getLogger(__name__)
 class BrokeredProducer(BaseProducer):
     can_recycle = True
 
-    def __init__(self, broker: Broker) -> None:
+    def __init__(self, broker: Broker, shared: SharedAsyncObjectsProtocol) -> None:
         self.production_task: Optional[asyncio.Task] = None
         self.broker = broker
         self.dispatcher: Optional[DispatcherMain] = None

--- a/dispatcherd/producers/control.py
+++ b/dispatcherd/producers/control.py
@@ -4,6 +4,7 @@ import logging
 from typing import Optional
 
 from ..protocols import DispatcherMain
+from ..protocols import SharedAsyncObjects as SharedAsyncObjectsProtocol
 from .base import BaseProducer
 
 logger = logging.getLogger(__name__)
@@ -16,7 +17,7 @@ class ControlProducer(BaseProducer):
     Indirectly, this also allows tasks to start other tasks.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, shared: SharedAsyncObjectsProtocol) -> None:
         self.dispatcher: Optional[DispatcherMain] = None
         super().__init__()
 

--- a/dispatcherd/producers/on_start.py
+++ b/dispatcherd/producers/on_start.py
@@ -3,13 +3,14 @@ import logging
 from typing import Union
 
 from ..protocols import DispatcherMain
+from ..protocols import SharedAsyncObjects as SharedAsyncObjectsProtocol
 from .base import BaseProducer
 
 logger = logging.getLogger(__name__)
 
 
 class OnStartProducer(BaseProducer):
-    def __init__(self, task_list: dict[str, dict[str, Union[int, str]]]):
+    def __init__(self, task_list: dict[str, dict[str, Union[int, str]]], shared: SharedAsyncObjectsProtocol):
         self.task_list = task_list
         super().__init__()
 

--- a/dispatcherd/protocols.py
+++ b/dispatcherd/protocols.py
@@ -191,6 +191,11 @@ class WorkerData(Protocol):
     def get_by_id(self, worker_id: int) -> PoolWorker: ...
 
 
+class SharedAsyncObjects:
+    exit_event: asyncio.Event
+    forking_and_connecting_lock: asyncio.Lock  # Forking and locking may need to be serialized, which this does
+
+
 class WorkerPool(Protocol):
     """
     Describes an interface for a pool managing task workers.
@@ -202,8 +207,9 @@ class WorkerPool(Protocol):
     workers: WorkerData
     queuer: Queuer
     blocker: Blocker
+    shared: SharedAsyncObjects
 
-    async def start_working(self, dispatcher: 'DispatcherMain', exit_event: Optional[asyncio.Event] = None) -> None:
+    async def start_working(self, dispatcher: 'DispatcherMain') -> None:
         """Start persistent asyncio tasks, including asychronously starting worker subprocesses"""
         ...
 
@@ -239,7 +245,7 @@ class DispatcherMain(Protocol):
     """
 
     pool: WorkerPool
-    fd_lock: asyncio.Lock  # Forking and locking may need to be serialized, which this does
+    shared: SharedAsyncObjects
     producers: Iterable[Producer]
     delayer: Delayer
 

--- a/dispatcherd/service/asyncio_tasks.py
+++ b/dispatcherd/service/asyncio_tasks.py
@@ -2,7 +2,18 @@ import asyncio
 import logging
 from typing import Iterable, Optional
 
+from ..protocols import SharedAsyncObjects as SharedAsyncObjectsProtocol
+
 logger = logging.getLogger(__name__)
+
+
+class SharedAsyncObjects(SharedAsyncObjectsProtocol):
+    def __init__(self) -> None:
+        # General exit event for program
+        self.exit_event = asyncio.Event()
+        # Lock for file descriptor mgmnt - hold lock when forking or connecting, to avoid DNS hangs
+        # psycopg is well-behaved IFF you do not connect while forking, compare to AWX __clean_on_fork__
+        self.forking_and_connecting_lock = asyncio.Lock()
 
 
 class CallbackHolder:

--- a/dispatcherd/service/delayer.py
+++ b/dispatcherd/service/delayer.py
@@ -1,11 +1,10 @@
-import asyncio
 import logging
 import time
 from typing import Any, Callable, Coroutine, Iterator, Optional, cast
 
 from ..protocols import DelayCapsule as DelayCapsuleProtocol
-from ..protocols import SharedAsyncObjects as SharedAsyncObjectsProtocol
 from ..protocols import Delayer as DelayerProtocol
+from ..protocols import SharedAsyncObjects as SharedAsyncObjectsProtocol
 from .next_wakeup_runner import HasWakeup, NextWakeupRunner
 
 logger = logging.getLogger(__name__)

--- a/dispatcherd/service/delayer.py
+++ b/dispatcherd/service/delayer.py
@@ -4,6 +4,7 @@ import time
 from typing import Any, Callable, Coroutine, Iterator, Optional, cast
 
 from ..protocols import DelayCapsule as DelayCapsuleProtocol
+from ..protocols import SharedAsyncObjects as SharedAsyncObjectsProtocol
 from ..protocols import Delayer as DelayerProtocol
 from .next_wakeup_runner import HasWakeup, NextWakeupRunner
 
@@ -29,24 +30,22 @@ class Delayer(NextWakeupRunner, DelayerProtocol):
     def __init__(
         self,
         process_message_now: Callable[[dict[Any, Any]], Coroutine[Any, Any, tuple[str | None, str | None]]],
-        exit_event: Optional[asyncio.Event] = None,
+        shared: SharedAsyncObjectsProtocol,
     ) -> None:
         self.delayed_messages: set[DelayCapsuleProtocol] = set()
-        self.shutting_down = False
         self.process_message_now = process_message_now
         super().__init__(
             wakeup_objects=cast(set[HasWakeup], self.delayed_messages),
             process_object=self.run_delayed_capsule,  # type: ignore[arg-type] # takes capsules, not HasWakeups, which is more specific
             name='delayed_task_runner',
-            exit_event=exit_event,
+            shared=shared,
         )
 
     def __iter__(self) -> Iterator[DelayCapsuleProtocol]:
         return iter(self.delayed_messages)
 
     async def shutdown(self) -> None:
-        self.shutting_down = True
-        await super().shutdown()
+        await self.kick()
         for capsule in self.delayed_messages:
             logger.warning(f'Abandoning delayed task (due to shutdown) to run in {capsule.delay}, message={capsule.message}')
         self.delayed_messages = set()

--- a/dispatcherd/service/main.py
+++ b/dispatcherd/service/main.py
@@ -46,7 +46,7 @@ class DispatcherMain(DispatcherMainProtocol):
 
         self.metrics = metrics
 
-        self.delayer: DelayerProtocol = Delayer(self.process_message_now, shared=shared, exit_event=self.events.exit_event)
+        self.delayer: DelayerProtocol = Delayer(self.process_message_now, shared=shared)
 
     def receive_signal(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         logger.warning(f"Received exit signal args={args} kwargs={kwargs}")

--- a/dispatcherd/service/main.py
+++ b/dispatcherd/service/main.py
@@ -10,7 +10,9 @@ from ..producers import BrokeredProducer
 from ..protocols import Delayer as DelayerProtocol
 from ..protocols import DispatcherMain as DispatcherMainProtocol
 from ..protocols import DispatcherMetricsServer as DispatcherMetricsServerProtocol
-from ..protocols import Producer, WorkerPool
+from ..protocols import Producer
+from ..protocols import SharedAsyncObjects as SharedAsyncObjectsProtocol
+from ..protocols import WorkerPool
 from . import control_tasks
 from .asyncio_tasks import ensure_fatal, wait_for_any
 from .delayer import Delayer
@@ -18,28 +20,23 @@ from .delayer import Delayer
 logger = logging.getLogger(__name__)
 
 
-class DispatcherEvents:
-    "Benchmark tests have to re-create this because they use same object in different event loops"
-
-    def __init__(self) -> None:
-        self.exit_event: asyncio.Event = asyncio.Event()
-
-
 class DispatcherMain(DispatcherMainProtocol):
     def __init__(
-        self, producers: Iterable[Producer], pool: WorkerPool, node_id: Optional[str] = None, metrics: Optional[DispatcherMetricsServerProtocol] = None
+        self,
+        producers: Iterable[Producer],
+        pool: WorkerPool,
+        shared: SharedAsyncObjectsProtocol,
+        node_id: Optional[str] = None,
+        metrics: Optional[DispatcherMetricsServerProtocol] = None,
     ):
         self.received_count = 0
         self.control_count = 0
-        self.shutting_down = False
-        # Lock for file descriptor mgmnt - hold lock when forking or connecting, to avoid DNS hangs
-        # psycopg is well-behaved IFF you do not connect while forking, compare to AWX __clean_on_fork__
-        self.fd_lock = asyncio.Lock()
 
         # Save the associated dispatcher objects, usually created by factories
         # expected that these are not yet running any tasks
         self.pool = pool
         self.producers = producers
+        self.shared = shared
 
         # Identifer for this instance of the dispatcherd service, sent in reply messages
         if node_id:
@@ -47,15 +44,13 @@ class DispatcherMain(DispatcherMainProtocol):
         else:
             self.node_id = str(uuid4())
 
-        self.events: DispatcherEvents = DispatcherEvents()
-
         self.metrics = metrics
 
-        self.delayer: DelayerProtocol = Delayer(self.process_message_now, exit_event=self.events.exit_event)
+        self.delayer: DelayerProtocol = Delayer(self.process_message_now, shared=shared, exit_event=self.events.exit_event)
 
     def receive_signal(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         logger.warning(f"Received exit signal args={args} kwargs={kwargs}")
-        self.events.exit_event.set()
+        self.shared.exit_event.set()
 
     def get_status_data(self) -> dict[str, Any]:
         return {"received_count": self.received_count, "control_count": self.control_count, "pid": getpid()}
@@ -76,7 +71,7 @@ class DispatcherMain(DispatcherMainProtocol):
             loop.add_signal_handler(sig, self.receive_signal)
 
     async def shutdown(self) -> None:
-        self.shutting_down = True
+        self.shared.exit_event.set()  # may already be set
         logger.debug("Shutting down, starting with producers.")
         for producer in self.producers:
             try:
@@ -94,7 +89,7 @@ class DispatcherMain(DispatcherMainProtocol):
             logger.exception('Pool manager encountered error')
 
         logger.debug('Setting event to exit main loop')
-        self.events.exit_event.set()
+        self.shared.exit_event.set()
 
     async def connected_callback(self, producer: Producer) -> None:
         return
@@ -178,12 +173,12 @@ class DispatcherMain(DispatcherMainProtocol):
     async def start_working(self) -> None:
         logger.debug('Filling the worker pool')
         try:
-            await self.pool.start_working(self, exit_event=self.events.exit_event)
+            await self.pool.start_working(self)
         except Exception:
             logger.exception(f'Pool {self.pool} failed to start working')
-            self.events.exit_event.set()
+            self.shared.exit_event.set()
 
-        async with self.fd_lock:  # lots of connecting going on here
+        async with self.shared.forking_and_connecting_lock:  # lots of connecting going on here
             for producer in self.producers:
                 logger.debug(f'Starting task production from {producer}')
                 try:
@@ -222,7 +217,7 @@ class DispatcherMain(DispatcherMainProtocol):
 
     async def main_loop_wait(self) -> None:
         """Wait for an event that requires some kind of action by the main loop"""
-        events = [self.events.exit_event]
+        events = [self.shared.exit_event]
         names = ['exit_event_wait']
         for producer in self.producers:
             if not producer.can_recycle:
@@ -237,7 +232,7 @@ class DispatcherMain(DispatcherMainProtocol):
         metrics_task: Optional[asyncio.Task] = None
         if self.metrics:
             metrics_task = asyncio.create_task(self.metrics.start_server(self), name='metrics_server')
-            ensure_fatal(metrics_task, exit_event=self.events.exit_event)
+            ensure_fatal(metrics_task, exit_event=self.shared.exit_event)
 
         try:
             await self.start_working()
@@ -247,7 +242,7 @@ class DispatcherMain(DispatcherMainProtocol):
             while True:
                 await self.main_loop_wait()
 
-                if self.events.exit_event.is_set():
+                if self.shared.exit_event.is_set():
                     break  # If the exit event is set, terminate the process
                 else:
                     await self.recycle_broker_producers()  # Otherwise, one or some of the producers broke

--- a/dispatcherd/service/process.py
+++ b/dispatcherd/service/process.py
@@ -76,8 +76,14 @@ class ProcessManager:
     def __init__(self, settings: LazySettings = global_settings) -> None:
         self.ctx = multiprocessing.get_context(self.mp_context)
         self.finished_queue: multiprocessing.Queue = self.ctx.Queue()
-        settings_config: dict = settings.serialize()  # These are passed to the workers to initialize dispatcher settings
+
+        # Settings will be passed to the workers to initialize dispatcher settings
+        settings_config: dict = settings.serialize()
+        # Settings are passed as a JSON format string
+        # JSON is more type-restrictive than python pickle, which multiprocessing otherwise uses
+        # this assures we do not pass python objects inside of settings by accident
         self.settings_stash: str = json.dumps(settings_config)
+
         self._loop: Optional[asyncio.AbstractEventLoop] = None
 
     def get_event_loop(self) -> asyncio.AbstractEventLoop:

--- a/dispatcherd/service/process.py
+++ b/dispatcherd/service/process.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import multiprocessing
 from multiprocessing.context import BaseContext
 from types import ModuleType
@@ -75,7 +76,8 @@ class ProcessManager:
     def __init__(self, settings: LazySettings = global_settings) -> None:
         self.ctx = multiprocessing.get_context(self.mp_context)
         self.finished_queue: multiprocessing.Queue = self.ctx.Queue()
-        self.settings_stash: dict = settings.serialize()  # These are passed to the workers to initialize dispatcher settings
+        settings_config: dict = settings.serialize()  # These are passed to the workers to initialize dispatcher settings
+        self.settings_stash: str = json.dumps(settings_config)
         self._loop: Optional[asyncio.AbstractEventLoop] = None
 
     def get_event_loop(self) -> asyncio.AbstractEventLoop:

--- a/tests/integration/test_disruptions.py
+++ b/tests/integration/test_disruptions.py
@@ -46,7 +46,7 @@ async def test_sever_pg_connection(apg_dispatcher, pg_message):
 
     # Main loop (which test simulates) should wake up before infinity
     await asyncio.wait_for(apg_dispatcher.main_loop_wait(), timeout=3)
-    assert not apg_dispatcher.events.exit_event.is_set()
+    assert not apg_dispatcher.shared.exit_event.is_set()
     # Okay now fix the things
     await apg_dispatcher.recycle_broker_producers()
 

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -307,5 +307,5 @@ async def test_tasks_are_named(apg_dispatcher, python312):
         task_name = task.get_name()
         assert not task_name.startswith('Task-'), _stack_from_task(task)
 
-    apg_dispatcher.events.exit_event.set()
+    apg_dispatcher.shared.exit_event.set()
     await wait_task

--- a/tests/unit/service/producers/test_scheduled_producer.py
+++ b/tests/unit/service/producers/test_scheduled_producer.py
@@ -3,6 +3,7 @@ import asyncio
 import pytest
 
 from dispatcherd.producers import ScheduledProducer
+from dispatcherd.service.asyncio_tasks import SharedAsyncObjects
 
 
 class ItWorked(Exception):
@@ -25,7 +26,7 @@ async def run_schedules_for_a_while(producer):
 
 
 def test_scheduled_producer_with_options():
-    producer = ScheduledProducer({'tests.data.methods.print_hello': {'schedule': 0.1, 'on_duplicate': 'queue_one'}})
+    producer = ScheduledProducer({'tests.data.methods.print_hello': {'schedule': 0.1, 'on_duplicate': 'queue_one'}}, shared=SharedAsyncObjects())
 
     loop = asyncio.get_event_loop()
     with pytest.raises(ItWorked):

--- a/tests/unit/service/test_blocker.py
+++ b/tests/unit/service/test_blocker.py
@@ -2,6 +2,7 @@ import pytest
 
 from dispatcherd.service.pool import WorkerPool
 from dispatcherd.service.process import ProcessManager
+from dispatcherd.service.asyncio_tasks import SharedAsyncObjects
 from dispatcherd.registry import registry
 
 from tests.data.methods import print_hello
@@ -14,7 +15,7 @@ async def test_block_multiple_tasks(test_settings):
     assert task_data['on_duplicate'] == 'serial'
 
     pm = ProcessManager(settings=test_settings)
-    pool = WorkerPool(pm, min_workers=5, max_workers=5)
+    pool = WorkerPool(pm, min_workers=5, max_workers=5, shared=SharedAsyncObjects())
 
     await pool.dispatch_task(task_data.copy())
     assert list(pool.queuer) == [task_data]

--- a/tests/unit/test_next_wakeup_runner_errors.py
+++ b/tests/unit/test_next_wakeup_runner_errors.py
@@ -3,6 +3,7 @@ import time
 import pytest
 
 from dispatcherd.service.next_wakeup_runner import HasWakeup, NextWakeupRunner
+from dispatcherd.service.asyncio_tasks import SharedAsyncObjects
 
 
 # Dummy object that implements HasWakeup.
@@ -31,7 +32,7 @@ async def test_process_wakeups_normal():
     past_time = time.monotonic() - 5
     schedule = DummySchedule(past_time)
     # Use dummy_process_object that adds 10 seconds.
-    runner = NextWakeupRunner([schedule], dummy_process_object)
+    runner = NextWakeupRunner([schedule], dummy_process_object, shared=SharedAsyncObjects())
     current_time = time.monotonic()
     next_wakeup = await runner.process_wakeups(current_time)
     # The wakeup time should now be 10 seconds later than the original past time.
@@ -46,7 +47,7 @@ async def test_process_wakeups_error_propagation():
     past_time = time.monotonic() - 5
     schedule = DummySchedule(past_time)
     # Use failing_process_object that raises an exception.
-    runner = NextWakeupRunner([schedule], failing_process_object)
+    runner = NextWakeupRunner([schedule], failing_process_object, shared=SharedAsyncObjects())
     current_time = time.monotonic()
     with pytest.raises(ValueError, match="Processing error"):
         await runner.process_wakeups(current_time)


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcherd/issues/140

The code might not always look cleaner as a result of this change, but more importantly, the internal state of the program is simplified. There are no longer multiple `shutting_down` flags. There's just 1 event, and anything can either check it or wait for it. Those other flags were subservient to this event (which already existed anyway). The ownership of that `exit_event` is changed from `DispatcherMain` to "anyone can pull the fire alarm".