### PR TITLE
Add a metrics server that can be optionally enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
           python-version: ${{ matrix.py_version }}
 
       - name: Install dispatcherd
-        run: pip install -e .[pg_notify]
+        run: pip install -e .[pg_notify,metrics]
       - run: make postgres
-      - run: pip install pytest pytest-asyncio
+      - run: pip install pytest pytest-asyncio httpx
       - run: pytest tests/unit tests/integration -vv -s
 
   black:
@@ -60,7 +60,7 @@ jobs:
           show-progress: false
 
       - run: pip install mypy
-      - run: pip install -e .[pg_notify]
+      - run: pip install -e .[pg_notify,metrics]
       - run: python3 -m pip install types-PyYAML
       - run: mypy dispatcherd
 

--- a/README.md
+++ b/README.md
@@ -235,144 +235,32 @@ Dispatcherd is sponsored by [Red Hat, Inc](https://www.redhat.com).
 
 ## Metrics
 
-Start the dispatcher.
+You can run a demo of the metrics server. In your first terminal tab, run:
 
 ```
-pip install prometheus_client
+pip install .[pg_notify,metrics]
+dispatcherd
+```
 
-$ curl http://localhost:8070
+In another tab run:
 
+```
 curl http://localhost:8070
+```
+
+This should report metrics in the following general format:
+
+```
+$ curl http://localhost:8070
 # HELP dispatcher_messages_received_total Number of messages received by dispatchermain
 # TYPE dispatcher_messages_received_total counter
-dispatcher_messages_received_total 88.0
+dispatcher_messages_received_total 263.0
 # HELP dispatcher_control_messages_count_total Number of control messages received.
 # TYPE dispatcher_control_messages_count_total counter
-dispatcher_control_messages_count_total 10.0
-# HELP dispatcher_worker_created_at Creation time of worker
-# TYPE dispatcher_worker_created_at gauge
-dispatcher_worker_created_at{worker_index="0"} 286576.365272104
-dispatcher_worker_created_at{worker_index="1"} 286576.365368035
-dispatcher_worker_created_at{worker_index="2"} 286578.814706941
-dispatcher_worker_created_at{worker_index="3"} 286578.817639637
-dispatcher_worker_created_at{worker_index="4"} 286578.820265243
-dispatcher_worker_created_at{worker_index="5"} 286578.822075874
-dispatcher_worker_created_at{worker_index="6"} 286578.824725725
-dispatcher_worker_created_at{worker_index="7"} 286578.837810563
-dispatcher_worker_created_at{worker_index="8"} 286578.844329095
-dispatcher_worker_created_at{worker_index="9"} 286578.863277972
-dispatcher_worker_created_at{worker_index="10"} 286578.878555905
-dispatcher_worker_created_at{worker_index="11"} 286579.36656921
-# HELP dispatcher_worker_finished_count Finished count of tasks by the worker
-# TYPE dispatcher_worker_finished_count gauge
-dispatcher_worker_finished_count{worker_index="0"} 2.0
-dispatcher_worker_finished_count{worker_index="1"} 1.0
-dispatcher_worker_finished_count{worker_index="2"} 1.0
-dispatcher_worker_finished_count{worker_index="3"} 7.0
-dispatcher_worker_finished_count{worker_index="4"} 8.0
-dispatcher_worker_finished_count{worker_index="5"} 1.0
-dispatcher_worker_finished_count{worker_index="6"} 0.0
-dispatcher_worker_finished_count{worker_index="7"} 0.0
-dispatcher_worker_finished_count{worker_index="8"} 0.0
-dispatcher_worker_finished_count{worker_index="9"} 2.0
-dispatcher_worker_finished_count{worker_index="10"} 1.0
-dispatcher_worker_finished_count{worker_index="11"} 1.0
-# HELP dispatcher_worker_status Status of worker.
-# TYPE dispatcher_worker_status gauge
-dispatcher_worker_status{dispatcher_worker_status="error",worker_index="0"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="0"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="0"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="0"} 1.0
-dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="0"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="0"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="0"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="0"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="error",worker_index="1"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="1"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="1"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="1"} 1.0
-dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="1"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="1"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="1"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="1"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="error",worker_index="2"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="2"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="2"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="2"} 1.0
-dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="2"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="2"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="2"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="2"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="error",worker_index="3"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="3"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="3"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="3"} 1.0
-dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="3"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="3"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="3"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="3"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="error",worker_index="4"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="4"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="4"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="4"} 1.0
-dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="4"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="4"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="4"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="4"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="error",worker_index="5"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="5"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="5"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="5"} 1.0
-dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="5"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="5"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="5"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="5"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="error",worker_index="6"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="6"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="6"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="6"} 1.0
-dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="6"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="6"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="6"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="6"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="error",worker_index="7"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="7"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="7"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="7"} 1.0
-dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="7"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="7"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="7"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="7"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="error",worker_index="8"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="8"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="8"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="8"} 1.0
-dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="8"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="8"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="8"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="8"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="error",worker_index="9"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="9"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="9"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="9"} 1.0
-dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="9"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="9"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="9"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="9"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="error",worker_index="10"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="10"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="10"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="10"} 1.0
-dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="10"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="10"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="10"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="10"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="error",worker_index="11"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="11"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="11"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="11"} 1.0
-dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="11"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="11"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="11"} 0.0
-dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="11"} 0.0
+dispatcher_control_messages_count_total 0.0
+# HELP dispatcher_worker_count_total Number of workers running.
+# TYPE dispatcher_worker_count_total counter
+dispatcher_worker_count_total 3.0
 ```
+
+We expect to add more metrics in the future.

--- a/README.md
+++ b/README.md
@@ -232,3 +232,147 @@ For more information about getting in touch, see the
 ## Credits
 
 Dispatcherd is sponsored by [Red Hat, Inc](https://www.redhat.com).
+
+## Metrics
+
+Start the dispatcher.
+
+```
+pip install prometheus_client
+
+$ curl http://localhost:8070
+
+curl http://localhost:8070
+# HELP dispatcher_messages_received_total Number of messages received by dispatchermain
+# TYPE dispatcher_messages_received_total counter
+dispatcher_messages_received_total 88.0
+# HELP dispatcher_control_messages_count_total Number of control messages received.
+# TYPE dispatcher_control_messages_count_total counter
+dispatcher_control_messages_count_total 10.0
+# HELP dispatcher_worker_created_at Creation time of worker
+# TYPE dispatcher_worker_created_at gauge
+dispatcher_worker_created_at{worker_index="0"} 286576.365272104
+dispatcher_worker_created_at{worker_index="1"} 286576.365368035
+dispatcher_worker_created_at{worker_index="2"} 286578.814706941
+dispatcher_worker_created_at{worker_index="3"} 286578.817639637
+dispatcher_worker_created_at{worker_index="4"} 286578.820265243
+dispatcher_worker_created_at{worker_index="5"} 286578.822075874
+dispatcher_worker_created_at{worker_index="6"} 286578.824725725
+dispatcher_worker_created_at{worker_index="7"} 286578.837810563
+dispatcher_worker_created_at{worker_index="8"} 286578.844329095
+dispatcher_worker_created_at{worker_index="9"} 286578.863277972
+dispatcher_worker_created_at{worker_index="10"} 286578.878555905
+dispatcher_worker_created_at{worker_index="11"} 286579.36656921
+# HELP dispatcher_worker_finished_count Finished count of tasks by the worker
+# TYPE dispatcher_worker_finished_count gauge
+dispatcher_worker_finished_count{worker_index="0"} 2.0
+dispatcher_worker_finished_count{worker_index="1"} 1.0
+dispatcher_worker_finished_count{worker_index="2"} 1.0
+dispatcher_worker_finished_count{worker_index="3"} 7.0
+dispatcher_worker_finished_count{worker_index="4"} 8.0
+dispatcher_worker_finished_count{worker_index="5"} 1.0
+dispatcher_worker_finished_count{worker_index="6"} 0.0
+dispatcher_worker_finished_count{worker_index="7"} 0.0
+dispatcher_worker_finished_count{worker_index="8"} 0.0
+dispatcher_worker_finished_count{worker_index="9"} 2.0
+dispatcher_worker_finished_count{worker_index="10"} 1.0
+dispatcher_worker_finished_count{worker_index="11"} 1.0
+# HELP dispatcher_worker_status Status of worker.
+# TYPE dispatcher_worker_status gauge
+dispatcher_worker_status{dispatcher_worker_status="error",worker_index="0"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="0"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="0"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="0"} 1.0
+dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="0"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="0"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="0"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="0"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="error",worker_index="1"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="1"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="1"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="1"} 1.0
+dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="1"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="1"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="1"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="1"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="error",worker_index="2"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="2"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="2"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="2"} 1.0
+dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="2"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="2"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="2"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="2"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="error",worker_index="3"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="3"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="3"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="3"} 1.0
+dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="3"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="3"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="3"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="3"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="error",worker_index="4"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="4"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="4"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="4"} 1.0
+dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="4"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="4"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="4"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="4"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="error",worker_index="5"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="5"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="5"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="5"} 1.0
+dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="5"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="5"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="5"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="5"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="error",worker_index="6"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="6"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="6"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="6"} 1.0
+dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="6"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="6"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="6"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="6"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="error",worker_index="7"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="7"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="7"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="7"} 1.0
+dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="7"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="7"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="7"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="7"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="error",worker_index="8"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="8"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="8"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="8"} 1.0
+dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="8"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="8"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="8"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="8"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="error",worker_index="9"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="9"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="9"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="9"} 1.0
+dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="9"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="9"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="9"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="9"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="error",worker_index="10"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="10"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="10"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="10"} 1.0
+dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="10"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="10"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="10"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="10"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="error",worker_index="11"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="exited",worker_index="11"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="initialized",worker_index="11"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="ready",worker_index="11"} 1.0
+dispatcher_worker_status{dispatcher_worker_status="retired",worker_index="11"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="spawned",worker_index="11"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="starting",worker_index="11"} 0.0
+dispatcher_worker_status{dispatcher_worker_status="stopping",worker_index="11"} 0.0
+```

--- a/dispatcher.yml
+++ b/dispatcher.yml
@@ -8,6 +8,8 @@ service:
     scaledown_wait: 15  # seconds
   main_kwargs:
     node_id: demo-server-a
+  metrics_kwargs:
+    log_level: debug
 brokers:
   pg_notify:
     config:

--- a/dispatcherd/protocols.py
+++ b/dispatcherd/protocols.py
@@ -193,6 +193,17 @@ class WorkerPool(Protocol):
     async def shutdown(self) -> None: ...
 
 
+class DispatcherMetricsServer(Protocol):
+    """
+    Metrics object will be created by factories.
+
+    If the extra is not installed, we may not have needed python dependencies.
+    This only needs to capture the interace of the initialized object with DispatcherMain.
+    """
+
+    async def start_server(self, dispatcher: 'DispatcherMain') -> None: ...
+
+
 class DispatcherMain(Protocol):
     """
     Describes the primary dispatcherd interface.
@@ -206,6 +217,9 @@ class DispatcherMain(Protocol):
     delayed_messages: set
     fd_lock: asyncio.Lock  # Forking and locking may need to be serialized, which this does
     producers: Iterable[Producer]
+
+    received_count: int
+    control_count: int
 
     async def main(self) -> None:
         """This is the method that runs the service, bring your own event loop"""

--- a/dispatcherd/service/main.py
+++ b/dispatcherd/service/main.py
@@ -272,6 +272,7 @@ class DispatcherMain(DispatcherMainProtocol):
         metrics_task: Optional[asyncio.Task] = None
         if self.metrics:
             metrics_task = asyncio.create_task(self.metrics.start_server(self), name='metrics_server')
+            ensure_fatal(metrics_task, exit_event=self.events.exit_event)
 
         try:
             await self.start_working()

--- a/dispatcherd/service/main.py
+++ b/dispatcherd/service/main.py
@@ -1,6 +1,17 @@
 import asyncio
 import json
 import logging
+import prometheus_client
+from prometheus_client import (
+    generate_latest,
+    Gauge,
+    Counter,
+    Enum,
+    CollectorRegistry,
+    parser,
+)
+from prometheus_client.core import GaugeMetricFamily, CounterMetricFamily, REGISTRY, StateSetMetricFamily
+from prometheus_client.registry import Collector
 import signal
 import time
 from os import getpid
@@ -15,6 +26,53 @@ from .asyncio_tasks import ensure_fatal, wait_for_any
 from .next_wakeup_runner import HasWakeup, NextWakeupRunner
 
 logger = logging.getLogger(__name__)
+
+
+class MetricsNamespace:
+    def __init__(self, namespace):
+        self._namespace = namespace
+
+
+class MetricsServerSettings(MetricsNamespace):
+    def port(self):
+        return 8070
+
+
+class MetricsServer(MetricsServerSettings):
+    def __init__(self, namespace, registry):
+        MetricsNamespace.__init__(self, namespace)
+        self._registry = registry
+
+        self._server = None
+        self._tid = None
+
+    def start(self):
+        try:
+            # TODO: addr for ipv6 ?
+            self._server, self._tid = prometheus_client.start_http_server(self.port(), addr='localhost', registry=self._registry)
+        except Exception:
+            logger.error(f"MetricsServer failed to start for service '{self._namespace}.")
+            raise
+        
+    def stop(self):
+        self._server.shutdown()
+        self._tid.join()
+
+
+class CustomCollector(Collector):
+    def __init__(self, do_metrics):
+        self._do_metrics = do_metrics
+
+    def collect(self):
+        for m in self._do_metrics():
+            yield m
+
+
+class DispatcherMetricsServer(MetricsServer):
+    def __init__(self, do_metrics):
+        registry = CollectorRegistry(auto_describe=True)
+        registry.register(CustomCollector(do_metrics))
+        super().__init__('dispatcherd', registry)
 
 
 class DispatcherEvents:
@@ -61,6 +119,8 @@ class DispatcherMain(DispatcherMainProtocol):
             self.node_id = str(uuid4())
 
         self.events: DispatcherEvents = DispatcherEvents()
+        
+        self._metrics_server = DispatcherMetricsServer(self.do_metrics)
 
         self.delayed_runner = NextWakeupRunner(self.delayed_messages, self.process_delayed_task, name='delayed_task_runner')
         self.delayed_runner.exit_event = self.events.exit_event
@@ -268,6 +328,8 @@ class DispatcherMain(DispatcherMainProtocol):
             current_task.set_name('dispatcherd_service_main')
 
         await self.connect_signals()
+        
+        self.start_metrics()
 
         try:
             await self.start_working()
@@ -286,5 +348,58 @@ class DispatcherMain(DispatcherMainProtocol):
             await self.shutdown()
 
             await self.cancel_tasks()
+            
+            self.stop_metrics()
 
         logger.debug('Dispatcherd loop fully completed')
+
+    def start_metrics(self) -> None:
+        self._metrics_server.start()
+
+    def stop_metrics(self) -> None:
+        self._metrics_server.stop()
+        
+    def do_metrics(self) -> None:
+        yield CounterMetricFamily(
+            f'dispatcher_messages_received_total',
+            'Number of messages received by dispatchermain',
+            value=self.received_count,
+        )
+        yield CounterMetricFamily(
+            f'dispatcher_control_messages_count',
+            'Number of control messages received.',
+            value=self.control_count,
+        )
+        created_at = GaugeMetricFamily(
+            f'dispatcher_worker_created_at',
+            'Creation time of worker',
+            labels=['worker_index'],
+        )
+        finished_count = GaugeMetricFamily(
+            f'dispatcher_worker_finished_count',
+            'Finished count of tasks by the worker',
+            labels=['worker_index'],
+        )
+        worker_status = StateSetMetricFamily(
+            f'dispatcher_worker_status',
+            'Status of worker.',
+            labels=['worker_index']
+        )
+        
+
+        for worker_index, worker in self.pool.workers.items():
+            created_at.add_metric([f'{worker_index}'], worker.created_at)
+            finished_count.add_metric([f'{worker_index}'], worker.finished_count)
+            worker_status.add_metric([f'{worker_index}'], {
+                'initialized': worker.status == 'initialized',
+                'spawned': worker.status == 'spawned',
+                'starting': worker.status == 'starting',
+                'ready': worker.status == 'ready',
+                'stopping': worker.status == 'stopping',
+                'exited': worker.status == 'exited',
+                'error': worker.status == 'error',
+                'retired': worker.status == 'retired'
+            })
+        yield created_at
+        yield finished_count
+        yield worker_status

--- a/dispatcherd/service/metrics.py
+++ b/dispatcherd/service/metrics.py
@@ -1,0 +1,74 @@
+import logging
+from typing import Any, Generator
+
+# Metrics library
+from prometheus_client import CollectorRegistry, make_asgi_app
+
+# For production of the metrics
+from prometheus_client.core import CounterMetricFamily
+from prometheus_client.metrics_core import Metric
+from prometheus_client.registry import Collector
+
+# General ASGI python web server, interfaces with prometheus-client lib by the ASGI standard
+from uvicorn.config import Config
+from uvicorn.server import Server
+
+from ..protocols import DispatcherMain
+
+logger = logging.getLogger(__name__)
+
+
+def metrics_data(dispatcher: DispatcherMain) -> Generator[Metric, Any, Any]:
+    """
+    Called each time metrics are gathered
+    This defines all the metrics collected and gets them from the dispatcher object
+    """
+    yield CounterMetricFamily(
+        'dispatcher_messages_received_total',
+        'Number of messages received by dispatchermain',
+        value=dispatcher.received_count,
+    )
+    yield CounterMetricFamily(
+        'dispatcher_control_messages_count',
+        'Number of control messages received.',
+        value=dispatcher.control_count,
+    )
+    yield CounterMetricFamily(
+        'dispatcher_worker_count',
+        'Number of workers running.',
+        value=len(list(dispatcher.pool.workers)),
+    )
+
+
+class CustomCollector(Collector):
+    def __init__(self, dispatcher: DispatcherMain) -> None:
+        self.dispatcher = dispatcher
+
+    def collect(self) -> Generator[Metric, Any, Any]:
+        for m in metrics_data(self.dispatcher):
+            yield m
+
+
+class DispatcherMetricsServer:
+    def __init__(self, port: int = 8070, log_level: str = 'info', host: str = "localhost") -> None:
+        self.port = port
+        self.log_level = log_level
+        self.host = host
+
+    async def start_server(self, dispatcher: DispatcherMain) -> None:
+        """Run Prometheus metrics ASGI app forever."""
+        registry = CollectorRegistry(auto_describe=True)
+        registry.register(CustomCollector(dispatcher))
+
+        app = make_asgi_app(registry=registry)
+
+        # Explanation:
+        # loop should default to asyncio anyway with uvicorn
+        # lifespan events are apart of ASGI 3.0 protocol, but prometheus client does not implement them
+        #   so it makes sense for that to be unconditionally off
+        config = Config(app=app, host=self.host, port=self.port, log_level=self.log_level, loop="asyncio", lifespan="off")
+        server = Server(config)
+
+        # Host and port are printed in Uvicorn logging
+        logger.info(f'Starting dispatcherd prometheus server log_level={self.log_level}')
+        await server.serve()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ line_length = 160
 
 [project.optional-dependencies]
 pg_notify = ["psycopg[binary]>=3.2.4"]
+metrics = ["uvicorn[standard]", "prometheus-client"]
 
 [tool.pytest.ini_options]
 log_cli_level = "DEBUG"

--- a/schema.json
+++ b/schema.json
@@ -35,6 +35,11 @@
     "main_kwargs": {
       "node_id": "typing.Optional[str]"
     },
+    "metrics_kwargs": {
+      "host": "<class 'str'>",
+      "port": "<class 'int'>",
+      "log_level": "<class 'str'>"
+    },
     "process_manager_kwargs": {
       "preload_modules": "typing.Optional[list[str]]"
     },

--- a/tests/integration/test_metrics_use.py
+++ b/tests/integration/test_metrics_use.py
@@ -1,0 +1,53 @@
+import asyncio
+import logging
+import httpx
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from dispatcherd.protocols import DispatcherMain
+
+logger = logging.getLogger(__name__)
+
+
+TEST_METRICS_PORT = 18080
+
+
+@pytest.fixture(scope='session')
+def metrics_config():
+    return {
+        "version": 2,
+        "brokers": {},
+        "service": {"main_kwargs": {"node_id": "metrics-test-server"}, "metrics_kwargs": {"log_level": "debug", "port": TEST_METRICS_PORT}},
+    }
+
+
+@pytest_asyncio.fixture
+async def ametrics_dispatcher(metrics_config, adispatcher_factory) -> AsyncIterator[DispatcherMain]:
+    async with adispatcher_factory(metrics_config) as dispatcher:
+        yield dispatcher
+
+
+async def aget_metrics():
+    async with httpx.AsyncClient() as client:
+        response = await client.get(f"http://localhost:{TEST_METRICS_PORT}")
+        return response
+
+
+@pytest.mark.asyncio
+async def test_get_metrics(ametrics_dispatcher):
+    assert ametrics_dispatcher.metrics.port == TEST_METRICS_PORT  # sanity, that config took effect
+
+    # Metrics server task starts from the main method
+    main_task = asyncio.create_task(ametrics_dispatcher.main_as_task())
+
+    # Actual test and assertion
+    get_task = asyncio.create_task(aget_metrics())
+    resp = await get_task
+    assert resp.status_code == 200
+    assert "dispatcher_messages_received_total" in resp.text
+
+    # Normally handled by fixture, we made a main loop task, so take care of our own task
+    await ametrics_dispatcher.shutdown()
+    await main_task


### PR DESCRIPTION
Replaces https://github.com/ansible/dispatcherd/pull/116

This takes a pivot from what I initially suggested, which was to have AWX start the thread.

That was a terrible idea, because nobody anywhere should be starting any threads here. Our hangup was that the library `prometheus-client` didn't obviously implement an asyncio version of their server. Oh, but they did! It just needs an intermediary of uvicorn.

After learning about how we can use this full-asyncio solution, I'm very comfortable with implementing the entire thing natively in dispatcherd. This PR is intended to offer the meat of the integration work for that - putting the metrics kwargs into the dispatcherd config system, adding that tasks to our tasks.

By default this will not be enabled, which is what you get if you don't include `metrics_kwargs`. This seems for the best, because you really shouldn't be accepting whatever default port it runs on in AWX or eda-server integration. Also, the dependencies are added as an _extra_ because I expect we'll have a bunch of dependency issues once this gets used downstream.