### PR TITLE
chore: ensure httpx as dev dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dispatcherd
         run: pip install -e .[pg_notify,metrics]
       - run: make postgres
-      - run: pip install pytest pytest-asyncio httpx
+      - run: pip install -r requirements_dev.txt
       - name: Run synchronous tests
         run: pytest tests/ -vv -s
       - name: Run pytest-asyncio tests

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-asyncio
 pytest-benchmark
+httpx


### PR DESCRIPTION
Ensure httpx is a dev dependency and make requirements_dev as single source of truth for dependencies. 