### PR TITLE
feat: set max_workers by default based on cpu count

### DIFF
--- a/dispatcherd/config.py
+++ b/dispatcherd/config.py
@@ -19,8 +19,6 @@ class DispatcherSettings:
         # Automatic defaults
         if 'pool_kwargs' not in self.service:
             self.service['pool_kwargs'] = {}
-        if 'max_workers' not in self.service['pool_kwargs']:
-            self.service['pool_kwargs']['max_workers'] = 3
 
     def serialize(self):
         return dict(version=self.version, brokers=self.brokers, producers=self.producers, service=self.service, publish=self.publish, worker=self.worker)

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import multiprocessing
 import os
 import signal
 import time
@@ -200,13 +201,17 @@ class WorkerPool(WorkerPoolProtocol):
         process_manager: ProcessManager,
         shared: SharedAsyncObjectsProtocol,
         min_workers: int = 1,
-        max_workers: int = 4,
+        max_workers: Optional[int] = None,
         scaledown_wait: float = 15.0,
         scaledown_interval: float = 15.0,
         worker_stop_wait: float = 30.0,
         worker_removal_wait: float = 30.0,
     ) -> None:
         self.min_workers = min_workers
+
+        if max_workers is None:
+            max_workers = multiprocessing.cpu_count()
+
         self.max_workers = max_workers
         self.process_manager = process_manager
         self.shared = shared

--- a/schema.json
+++ b/schema.json
@@ -26,7 +26,7 @@
   "service": {
     "pool_kwargs": {
       "min_workers": "<class 'int'>",
-      "max_workers": "<class 'int'>",
+      "max_workers": "typing.Optional[int]",
       "scaledown_wait": "<class 'float'>",
       "scaledown_interval": "<class 'float'>",
       "worker_stop_wait": "<class 'float'>",

--- a/tests/unit/service/test_pool.py
+++ b/tests/unit/service/test_pool.py
@@ -10,7 +10,7 @@ from dispatcherd.service.pool import WorkerPool
 from dispatcherd.service.main import DispatcherMain
 from dispatcherd.service.process import ProcessManager
 from dispatcherd.service.asyncio_tasks import SharedAsyncObjects
-
+import multiprocessing
 
 @pytest.fixture
 def pool_factory(test_settings) -> Callable[..., WorkerPool]:
@@ -140,3 +140,11 @@ async def test_shutdown_is_idepotent(pool_factory):
 
     await pool.shutdown()
     await pool.shutdown()  # weird to shutdown twice, but... just return
+
+
+@pytest.mark.asyncio
+async def test_auto_count_max_workers(pool_factory):
+    "Test max_workers is set to the number of CPUs if not set"
+    cpu_count = multiprocessing.cpu_count()
+    pool = pool_factory(max_workers=None)
+    assert pool.max_workers == cpu_count

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -26,7 +26,6 @@ def test_serialize_settings(test_settings):
     assert 'publish' in config
     assert config['publish'] == {}
     assert 'pg_notify' in config['brokers']
-    assert config['service']['pool_kwargs']['max_workers'] == 3
 
     re_loaded = DispatcherSettings(config)
     assert re_loaded.brokers == test_settings.brokers


### PR DESCRIPTION
In the most of the cases we want to set the max number of workers equal to the cpu cores available. This can be set by default by the system if the configuration does not provide a value, allowing a more concise configuration. 

It also removes the default at the instantiation level, unaligned with previous existing default value in the class. 