### PR TITLE
Worker rotation via the longest-idle criteria

### DIFF
--- a/dispatcherd/protocols.py
+++ b/dispatcherd/protocols.py
@@ -212,6 +212,8 @@ class WorkerData(Protocol):
 
     def get_by_id(self, worker_id: int) -> PoolWorker: ...
 
+    def move_to_end(self, worker_id: int) -> None: ...
+
 
 class SharedAsyncObjects:
     exit_event: asyncio.Event

--- a/tests/unit/service/test_worker_order.py
+++ b/tests/unit/service/test_worker_order.py
@@ -1,0 +1,104 @@
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from dispatcherd.protocols import DispatcherMain
+from dispatcherd.testing.asyncio import adispatcher_service
+
+
+@pytest.fixture(scope='session')
+def order_config():
+    return {
+        "version": 2,
+        "service": {
+            "pool_kwargs": {"min_workers": 2, "max_workers": 2},
+            "main_kwargs": {"node_id": "order-test"},
+        },
+    }
+
+
+@pytest_asyncio.fixture
+async def aorder_dispatcher(order_config) -> AsyncIterator[DispatcherMain]:
+    async with adispatcher_service(order_config) as dispatcher:
+        yield dispatcher
+
+
+@pytest.mark.asyncio
+async def test_workers_reorder_and_dispatch_longest_idle(aorder_dispatcher):
+    pool = aorder_dispatcher.pool
+    assert list(pool.workers.workers.keys()) == [0, 1]
+
+    pool.events.work_cleared.clear()
+    await aorder_dispatcher.process_message({
+        "task": "tests.data.methods.sleep_function",
+        "kwargs": {"seconds": 0.1},
+        "uuid": "t1",
+    })
+    await aorder_dispatcher.process_message({
+        "task": "tests.data.methods.sleep_function",
+        "kwargs": {"seconds": 0.05},
+        "uuid": "t2",
+    })
+    await asyncio.wait_for(pool.events.work_cleared.wait(), timeout=1)
+
+    assert list(pool.workers.workers.keys()) == [1, 0]
+
+    pool.events.work_cleared.clear()
+    await aorder_dispatcher.process_message({
+        "task": "tests.data.methods.sleep_function",
+        "kwargs": {"seconds": 0.01},
+        "uuid": "t3",
+    })
+    await asyncio.sleep(0.01)
+    assert pool.workers.get_by_id(1).current_task["uuid"] == "t3"
+    assert pool.workers.get_by_id(0).current_task is None
+    await asyncio.wait_for(pool.events.work_cleared.wait(), timeout=1)
+
+    pool.events.work_cleared.clear()
+    await aorder_dispatcher.process_message({
+        "task": "tests.data.methods.sleep_function",
+        "kwargs": {"seconds": 0.01},
+        "uuid": "t4",
+    })
+    await asyncio.sleep(0.01)
+    assert pool.workers.get_by_id(0).current_task["uuid"] == "t4"
+    await asyncio.wait_for(pool.events.work_cleared.wait(), timeout=1)
+
+    assert list(pool.workers.workers.keys()) == [1, 0]
+
+
+@pytest.mark.asyncio
+async def test_process_finished_with_removed_worker():
+    """Test that process_finished handles KeyError gracefully when worker has been removed
+
+    This simulates the race condition where a worker finishes a task, but has been
+    removed from self.workers before process_finished is called.
+    """
+    from unittest.mock import MagicMock, patch
+    from dispatcherd.service.pool import WorkerData, PoolWorker
+
+    # Create a minimal WorkerData instance
+    worker_data = WorkerData()
+
+    # Create a mock worker
+    mock_process = MagicMock()
+    worker = PoolWorker(worker_id=0, process=mock_process)
+    worker.current_task = {"uuid": "test-uuid", "task": "test.task"}
+    worker.finished_count = 0
+
+    # Add worker then remove it (simulating the race condition)
+    worker_data.add_worker(worker)
+    worker_data.remove_by_id(0)
+    assert 0 not in worker_data
+
+    # Mock the logger to verify the warning is logged
+    with patch('dispatcherd.service.pool.logger') as mock_logger:
+        # Call move_to_end on the removed worker - should not raise KeyError
+        worker_data.move_to_end(0)
+
+        # Verify the warning was logged
+        mock_logger.warning.assert_called_once()
+        warning_call = mock_logger.warning.call_args[0][0]
+        assert "Attempted to move worker_id=0 to end, but worker was already removed" in warning_call


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcherd/issues/156

This doesn't make it configurable, because I see no need to make it configurable. Workers are interchangeable, and this is the only reason we have to have any selection criteria for free workers (postgres connection timeout).

I thought about tracking the last-finished timestamp in the `PoolWorker` data structure, but then realized that is way more complicated than the obvious solution. So I thought `dequeue`, but that also gets complicated because there aren't good built-ins for this. On other other hand, `OrderedDict` is just :100: 

Finished a task? Go to the end of the line.

Need a worker to start a task? Look starting from the front of the line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements worker rotation based on longest-idle by switching to OrderedDict and moving finished workers to the end, with tests covering ordering and race handling.
> 
> - **Pool/Worker management**:
>   - Use `OrderedDict` for `WorkerData.workers` to preserve order.
>   - On task completion (`process_finished`), call `workers.move_to_end(worker_id)` to rotate finished worker to the back (longest-idle dispatch).
> - **Protocols**:
>   - Add `WorkerData.move_to_end(worker_id)` to `dispatcherd/protocols.py`.
> - **Robustness**:
>   - `WorkerData.move_to_end` handles missing worker with a warning (no exception).
> - **Tests**:
>   - Add `tests/unit/service/test_worker_order.py` verifying reordering and that the longest-idle worker is dispatched next.
>   - Test graceful handling and logging when moving a removed worker.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 346112ff253baf6e53ca8fc4828e1a3982163250. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->