### PR TITLE
chore: move default pg_notify dependency to pure python psycopg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,9 @@ profile = "black"
 line_length = 160
 
 [project.optional-dependencies]
-pg_notify = ["psycopg[binary]>=3.2.4"]
+pg_notify = ["psycopg>=3.2.4"]
+pg_notify_dev = ["psycopg[binary]>=3.2.4"]
+pg_notify_prod = ["psycopg[c]>=3.2.4"]
 metrics = ["uvicorn[standard]", "prometheus-client"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Projects we own we want to set the dependency of psycopg as the default python implementation to allow offline builds or support platforms where psycopg-binary is no available. Additionally, I add to new dependencies pointing to the C compiled version and the precompiled binary (dev and prod suffixes). 

This is aligned with our [internal strategy](https://handbook.eng.ansible.com/proposals/SDP-0016-Downstream-Build-Modernization/P11-psycopg-c-for-downstream-builds#changes-to-ansible-owned-upstream-project-requirements) for managing psycopg dependency