### PR TITLE
Add fail-fast: false to test matrix to prevent job cancellations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     strategy:
+      fail-fast: false
       matrix:
         py_version:
           - '3.12'


### PR DESCRIPTION
I didn't catch Alan's last comment in https://github.com/ansible/dispatcherd/pull/189 before merging. This PR is to add fail-fast: false to test matrix to prevent job cancellations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disable fail-fast in the GitHub Actions test matrix to avoid cancelling remaining jobs on first failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b5797992e9f1eff8f35027330fae35232b994c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->