### PR TITLE
Disable SonarCloud cognitive complexity rule in sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,8 +20,11 @@ sonar.python.coverage.reportPaths=coverage.xml
 # Coverage Requirements (80% minimum)
 sonar.coverage.exclusions=**/tests/**,**/__pycache__/**
 
-# Disable cognitive complexity rule
-sonar.issue.ignore.multicriteria=e1
+# Disable cognitive complexity and unused parameter rules
+sonar.issue.ignore.multicriteria=e1,e2
 
 sonar.issue.ignore.multicriteria.e1.ruleKey=python:S3776
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.py
+
+sonar.issue.ignore.multicriteria.e2.ruleKey=python:S1172
+sonar.issue.ignore.multicriteria.e2.resourceKey=**/*.py


### PR DESCRIPTION
This PR is to disable the SonarCloud cognitive complexity rule to make SonarCloud feedback less noisy for non-blocking detection.

What's now disabled:
  1. python:S3776 - Cognitive Complexity 
  2. python:S1172 - Unused function parameters


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `sonar-project.properties` to ignore `python:S3776` and `python:S1172` for all Python files.
> 
> - **SonarCloud configuration** (`sonar-project.properties`):
>   - Ignore `python:S3776` (Cognitive Complexity) for `**/*.py`.
>   - Ignore `python:S1172` (Unused function parameters) for `**/*.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c223dd2c012396940bdcd72fa3303341ce5cd30d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->