### PR TITLE
Pretify the status for producers

### DIFF
--- a/dispatcherd/producers/base.py
+++ b/dispatcherd/producers/base.py
@@ -23,3 +23,7 @@ class BaseProducer(ProducerProtocol):
             'produced_count': self.produced_count,
             'uptime_seconds': time.monotonic() - self.started_at,
         }
+
+    def __str__(self) -> str:
+        module_name = self.__class__.__module__.rsplit('.', 1)[-1]
+        return f'{module_name.replace("_", "-")}-producer'


### PR DESCRIPTION
The most minor of minor tweaks to improve the aesthetics of debugging commands.

before:

```
  producers:
    <dispatcherd.producers.control.ControlProducer object at 0x7f9ba5b0e550>:
      produced_count: 0
    <dispatcherd.producers.on_start.OnStartProducer object at 0x7f9ba5b0e3d0>:
      produced_count: 1
    <dispatcherd.producers.scheduled.ScheduledProducer object at 0x7f9ba5b0e210>:
      produced_count: 6
    pg_notify-producer:
      produced_count: 1
    socket-producer:
      produced_count: 2
```

after:

```
  node_id: demo-server-a
  producers:
    control-producer:
      produced_count: 0
    on-start-producer:
      produced_count: 1
    pg_notify-producer:
      produced_count: 0
    scheduled-producer:
      produced_count: 2
    socket-producer:
      produced_count: 1
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves readability of producer identifiers in status/debug displays.
> 
> - Adds `__str__` to `BaseProducer` (`dispatcherd/producers/base.py`) to return a dashed, module-derived name with `-producer` suffix (e.g., `scheduled-producer`) instead of the default object representation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddc5b3c0a635d05f742fb237523673f3d40e7b78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->