### PR TITLE
Track self-check status and improve logging

### DIFF
--- a/asyncio_tests/unit/test_control_cleanup.py
+++ b/asyncio_tests/unit/test_control_cleanup.py
@@ -43,7 +43,7 @@ class DummyBroker(Broker):
 async def test_acontrol_with_reply_resource_cleanup(monkeypatch):
     dummy_broker = DummyBroker()
 
-    def dummy_get_broker(broker_name, broker_config, channels=None):
+    def dummy_get_broker(broker_name, broker_config, channels=None, **kwargs):
         return dummy_broker
 
     monkeypatch.setattr("dispatcherd.control.get_broker", dummy_get_broker)
@@ -59,7 +59,7 @@ async def test_acontrol_with_reply_resource_cleanup(monkeypatch):
 async def test_acontrol_resource_cleanup(monkeypatch):
     dummy_broker = DummyBroker()
 
-    def dummy_get_broker(broker_name, broker_config, channels=None):
+    def dummy_get_broker(broker_name, broker_config, channels=None, **kwargs):
         return dummy_broker
 
     monkeypatch.setattr("dispatcherd.control.get_broker", dummy_get_broker)

--- a/dispatcherd/producers/base.py
+++ b/dispatcherd/producers/base.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 
 from ..protocols import Producer as ProducerProtocol
 
@@ -15,6 +16,10 @@ class BaseProducer(ProducerProtocol):
     def __init__(self) -> None:
         self.events = ProducerEvents()
         self.produced_count = 0
+        self.started_at = time.monotonic()
 
     def get_status_data(self) -> dict:
-        return {'produced_count': self.produced_count}
+        return {
+            'produced_count': self.produced_count,
+            'uptime_seconds': time.monotonic() - self.started_at,
+        }

--- a/tests/unit/service/test_dispatcher_recycles.py
+++ b/tests/unit/service/test_dispatcher_recycles.py
@@ -1,0 +1,21 @@
+from dispatcherd.producers.brokered import BrokeredProducer
+from dispatcherd.service.asyncio_tasks import SharedAsyncObjects
+
+
+class DummyBroker:
+    def get_self_check_stats(self):
+        return {'enabled': True, 'success_count': 1}
+
+
+def test_brokered_producer_reports_recycle_and_self_check_stats():
+    producer = BrokeredProducer(broker=DummyBroker(), shared=SharedAsyncObjects())
+
+    producer.record_recycle()
+    producer.record_recycle()
+
+    status = producer.get_status_data()
+    assert status['recycle_count'] == 2
+    broker_stats = status['broker_self_check']
+    assert broker_stats['enabled'] is True
+    assert broker_stats['success_count'] == 1
+    assert status['uptime_seconds'] >= 0

--- a/tests/unit/test_control_cleanup.py
+++ b/tests/unit/test_control_cleanup.py
@@ -1,7 +1,9 @@
 import json
 
+from dispatcherd.brokers.pg_notify import Broker as PGNotifyBroker
 from dispatcherd.control import Control
 from dispatcherd.protocols import Broker
+from tests.unit.utils import DummyAsyncConnection, DummySyncConnection
 
 
 class DummyBroker(Broker):
@@ -38,7 +40,7 @@ def test_control_with_reply_resource_cleanup(monkeypatch):
     """control_with_reply should close the broker when finished."""
     dummy_broker = DummyBroker()
 
-    def dummy_get_broker(broker_name, broker_config, channels=None):
+    def dummy_get_broker(broker_name, broker_config, channels=None, **kwargs):
         return dummy_broker
 
     monkeypatch.setattr("dispatcherd.control.get_broker", dummy_get_broker)
@@ -53,7 +55,7 @@ def test_control_resource_cleanup(monkeypatch):
     """control() should close the broker even when fire-and-forget."""
     dummy_broker = DummyBroker()
 
-    def dummy_get_broker(broker_name, broker_config, channels=None):
+    def dummy_get_broker(broker_name, broker_config, channels=None, **kwargs):
         return dummy_broker
 
     monkeypatch.setattr("dispatcherd.control.get_broker", dummy_get_broker)
@@ -61,3 +63,24 @@ def test_control_resource_cleanup(monkeypatch):
     control = Control(broker_name="dummy", broker_config={}, queue="test_queue")
     control.control(command="test_command", data={"foo": "bar"})
     assert dummy_broker.close_called is True
+
+
+def test_pg_notify_control_overrides_disable_self_checks():
+    control = Control(broker_name="pg_notify", broker_config={})
+    overrides = control._control_broker_overrides()
+    broker = PGNotifyBroker(
+        sync_connection=DummySyncConnection(),
+        async_connection=DummyAsyncConnection(),
+        channels=('reply_channel',),
+        **overrides,
+    )
+
+    assert broker.max_connection_idle_seconds is None
+    assert broker.max_self_check_message_age_seconds is None
+    assert broker.self_check_channel is None
+    assert all('self_check' not in channel for channel in broker.channels)
+    stats = broker.get_self_check_stats()
+    assert stats['enabled'] is False
+    assert stats['success_count'] == 0
+    assert stats['average_time_seconds'] is None
+    assert stats['max_time_seconds'] is None

--- a/tests/unit/test_pg_notify_self_check.py
+++ b/tests/unit/test_pg_notify_self_check.py
@@ -1,0 +1,46 @@
+import time
+
+import pytest
+
+from dispatcherd.brokers.pg_notify import Broker as PGNotifyBroker
+from tests.unit.utils import DummyAsyncConnection, DummySyncConnection
+
+
+def _build_broker():
+    return PGNotifyBroker(
+        sync_connection=DummySyncConnection(),
+        async_connection=DummyAsyncConnection(),
+        channels=('demo',),
+        max_connection_idle_seconds=5,
+        max_self_check_message_age_seconds=2,
+    )
+
+
+def _self_check_message(broker: PGNotifyBroker) -> dict:
+    return {'task': f'lambda: "{broker.broker_id}"'}
+
+
+def test_self_check_stats_success_updates_average_and_max():
+    broker = _build_broker()
+    broker.last_self_check_message_time = time.monotonic() - 0.5
+
+    broker.verify_self_check(_self_check_message(broker))
+
+    stats = broker.get_self_check_stats()
+    assert stats['enabled'] is True
+    assert stats['success_count'] == 1
+    assert stats['average_time_seconds'] == pytest.approx(0.5, rel=0.2)
+    assert stats['max_time_seconds'] == pytest.approx(0.5, rel=0.2)
+
+
+def test_self_check_failure_does_not_update_success_stats():
+    broker = _build_broker()
+    broker.last_self_check_message_time = time.monotonic() - 3
+
+    with pytest.raises(RuntimeError):
+        broker.verify_self_check(_self_check_message(broker))
+
+    stats = broker.get_self_check_stats()
+    assert stats['success_count'] == 0
+    assert stats['average_time_seconds'] is None
+    assert stats['max_time_seconds'] is None

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,0 +1,14 @@
+class DummySyncConnection:
+    def __init__(self):
+        self.closed = 0
+
+    def close(self):
+        self.closed = 1
+
+
+class DummyAsyncConnection:
+    def __init__(self):
+        self.closed = 0
+
+    async def close(self):
+        self.closed = 1


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcherd/issues/192

This adds an override kwarg in the `control.py` module so that the control brokers do not listen to the self-check channel or do anything with them.

It demotes the logs related to self-check, and in turn, puts the self-check data in the status data where it is probably more usable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces optional self-checks in `pg_notify` and surfaces metrics while ensuring control paths don't engage self-check logic.
> 
> - `dispatcherd/brokers/pg_notify.py`: Self-checks are now disabled when `max_connection_idle_seconds=None`; conditional setup of `self_check_channel`; guard `initiate_self_check`/`verify_self_check`; demote logs to debug; track successes and expose `get_self_check_stats()`.
> - `dispatcherd/control.py`: Add `_control_broker_overrides()` to disable broker self-checks for control operations; pass overrides to `get_broker` in sync/async control methods.
> - `dispatcherd/producers/base.py` and `brokered.py`: Add producer `uptime_seconds`, track/report `recycle_count`, and include broker `self_check` stats in `get_status_data()`.
> - Tests: New/updated tests for control cleanup, pg_notify self-check metrics/behavior, control overrides, and dummy connection utils.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b91d41bd26a5d3ed18006eac4670a8e5d003c458. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->