### PR TITLE
Use Python's native union type operator (|) 

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,7 @@
 import contextlib
 import logging
 
-from typing import Callable, AsyncIterator, Union
+from typing import Callable, AsyncIterator
 
 import pytest
 import pytest_asyncio
@@ -111,7 +111,7 @@ def registry() -> DispatcherMethodRegistry:
 @pytest.fixture
 def get_worker_data():
     "General utility for processing control-with-reply response"
-    def _rf(response_list: list[dict[str,Union[str,dict]]]) -> dict:
+    def _rf(response_list: list[dict[str,str|dict]]) -> dict:
         "Given some control-and-response data, assuming 1 node, 1 entry, get the task message"
         assert len(response_list) == 1
         response = response_list[0].copy()

--- a/dispatcherd/brokers/noop.py
+++ b/dispatcherd/brokers/noop.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any, AsyncGenerator, Callable, Coroutine, Iterator, Optional, Union
+from typing import Any, AsyncGenerator, Callable, Coroutine, Iterator, Optional
 
 from ..protocols import Broker as BrokerProtocol
 from ..protocols import BrokerSelfCheckStatus
@@ -23,7 +23,7 @@ class Broker(BrokerProtocol):
 
     async def aprocess_notify(
         self, connected_callback: Optional[Callable[[], Coroutine[Any, Any, None]]] = None
-    ) -> AsyncGenerator[tuple[Union[int, str], str], None]:
+    ) -> AsyncGenerator[tuple[int | str, str], None]:
         """No-op implementation that yields once after the forever loop."""
         if connected_callback:
             await connected_callback()
@@ -32,7 +32,7 @@ class Broker(BrokerProtocol):
             await asyncio.sleep(0.1)  # Prevent busy-waiting
         yield ('', '')  # Yield once to satisfy the AsyncGenerator return type
 
-    async def apublish_message(self, channel: Optional[str] = None, origin: Union[int, str, None] = None, message: str = '') -> None:
+    async def apublish_message(self, channel: Optional[str] = None, origin: int | str | None = None, message: str = '') -> None:
         """No-op implementation that does nothing."""
         logger.debug(f'No-op broker ignoring message of length {len(message)}')
 
@@ -42,7 +42,7 @@ class Broker(BrokerProtocol):
 
     def process_notify(
         self, connected_callback: Optional[Callable] = None, timeout: float = 5.0, max_messages: int | None = 1
-    ) -> Iterator[tuple[Union[int, str], str]]:
+    ) -> Iterator[tuple[int | str, str]]:
         """No-op implementation that yields nothing."""
         if connected_callback:
             connected_callback()

--- a/dispatcherd/brokers/socket.py
+++ b/dispatcherd/brokers/socket.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import os
 import socket
-from typing import Any, AsyncGenerator, Callable, Coroutine, Iterator, Optional, Union
+from typing import Any, AsyncGenerator, Callable, Coroutine, Iterator, Optional
 
 from ..chunking import split_message
 from ..protocols import Broker as BrokerProtocol
@@ -98,7 +98,7 @@ class Broker(BrokerProtocol):
 
     async def aprocess_notify(
         self, connected_callback: Optional[Callable[[], Coroutine[Any, Any, None]]] = None
-    ) -> AsyncGenerator[tuple[Union[int, str], str], None]:
+    ) -> AsyncGenerator[tuple[int | str, str], None]:
         if os.path.exists(self.socket_path):
             logger.debug(f'Deleted pre-existing {self.socket_path}')
             os.remove(self.socket_path)
@@ -155,7 +155,7 @@ class Broker(BrokerProtocol):
                 writer.close()
                 await writer.wait_closed()
 
-    async def apublish_message(self, channel: Optional[str] = '', origin: Union[int, str, None] = None, message: str = "") -> None:
+    async def apublish_message(self, channel: Optional[str] = '', origin: int | str | None = None, message: str = "") -> None:
         if isinstance(origin, int) and origin >= 0:
             client = self.clients.get(int(origin))
             if client:
@@ -177,7 +177,7 @@ class Broker(BrokerProtocol):
 
     def process_notify(
         self, connected_callback: Optional[Callable] = None, timeout: float = 5.0, max_messages: int | None = 1
-    ) -> Iterator[tuple[Union[int, str], str]]:
+    ) -> Iterator[tuple[int | str, str]]:
         try:
             with socket.socket(socket.AF_UNIX) as sock:
                 self.sock = sock

--- a/dispatcherd/control.py
+++ b/dispatcherd/control.py
@@ -3,7 +3,7 @@ import json
 import logging
 import time
 import uuid
-from typing import Optional, Union
+from typing import Optional
 
 from .chunking import ChunkAccumulator
 from .factories import get_broker
@@ -19,7 +19,7 @@ JSON_ERROR_STR = 'JSON parse error'
 def _ingest_reply_payload(
     accumulator: ChunkAccumulator,
     results: list[dict],
-    payload: Union[str, dict],
+    payload: str | dict,
     *,
     idx: int | None = None,
 ) -> bool:
@@ -86,7 +86,7 @@ class Control:
         return f"reply_to_{str(uuid.uuid4()).replace('-', '_')}"
 
     def create_message(self, command: str, reply_to: Optional[str] = None, send_data: Optional[dict] = None) -> str:
-        to_send: dict[str, Union[dict, str]] = {'control': command}
+        to_send: dict[str, dict | str] = {'control': command}
         if reply_to:
             to_send['reply_to'] = reply_to
         if send_data:

--- a/dispatcherd/producers/brokered.py
+++ b/dispatcherd/producers/brokered.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Iterable, Optional, Union
+from typing import Iterable, Optional
 
 from ..protocols import Broker, DispatcherMain
 from ..protocols import SharedAsyncObjects as SharedAsyncObjectsProtocol
@@ -57,7 +57,7 @@ class BrokeredProducer(BaseProducer):
             if reply_to and reply_payload:
                 await self.notify(channel=reply_to, origin=channel, message=reply_payload)
 
-    async def notify(self, channel: Optional[str] = None, origin: Optional[Union[int, str]] = None, message: str = '') -> None:
+    async def notify(self, channel: Optional[str] = None, origin: Optional[int | str] = None, message: str = '') -> None:
         await self.broker.apublish_message(channel=channel, origin=origin, message=message)
 
     async def shutdown(self) -> None:

--- a/dispatcherd/protocols.py
+++ b/dispatcherd/protocols.py
@@ -1,7 +1,7 @@
 import asyncio
 import multiprocessing
 from enum import Enum
-from typing import Any, AsyncGenerator, Callable, Coroutine, Iterable, Iterator, Optional, Protocol, Union
+from typing import Any, AsyncGenerator, Callable, Coroutine, Iterable, Iterator, Optional, Protocol
 
 from .chunking import ChunkAccumulator
 
@@ -23,7 +23,7 @@ class Broker(Protocol):
 
     async def aprocess_notify(
         self, connected_callback: Optional[Optional[Callable[[], Coroutine[Any, Any, None]]]] = None
-    ) -> AsyncGenerator[tuple[Union[int, str], str], None]:
+    ) -> AsyncGenerator[tuple[int | str, str], None]:
         """The generator of messages from the broker for the dispatcherd service
 
         The producer iterates this to produce tasks.
@@ -31,7 +31,7 @@ class Broker(Protocol):
         """
         yield ('', '')  # yield affects CPython type https://github.com/python/mypy/pull/18422
 
-    async def apublish_message(self, channel: Optional[str] = None, origin: Union[int, str, None] = None, message: str = '') -> None:
+    async def apublish_message(self, channel: Optional[str] = None, origin: int | str | None = None, message: str = '') -> None:
         """Asynchronously send a message to the broker, used by dispatcherd service for reply messages"""
         ...
 
@@ -41,7 +41,7 @@ class Broker(Protocol):
 
     def process_notify(
         self, connected_callback: Optional[Callable] = None, timeout: float = 5.0, max_messages: int | None = 1
-    ) -> Iterator[tuple[Union[int, str], str]]:
+    ) -> Iterator[tuple[int | str, str]]:
         """Synchronous method to generate messages from broker, used for synchronous control-and-reply"""
         ...
 
@@ -309,7 +309,7 @@ class DispatcherMain(Protocol):
         ...
 
     async def process_message(
-        self, payload: Union[dict, str], producer: Optional[Producer] = None, channel: Optional[str] = None
+        self, payload: dict | str, producer: Optional[Producer] = None, channel: Optional[str] = None
     ) -> tuple[Optional[str], Optional[str]]:
         """This is called by producers when a new request to run a task comes in"""
         ...
@@ -347,6 +347,6 @@ class TaskWorker(Protocol):
 
     def perform_work(self, message: dict) -> dict: ...
 
-    def get_ready_message(self) -> dict[str, Union[str, int]]: ...
+    def get_ready_message(self) -> dict[str, str | int]: ...
 
-    def get_shutdown_message(self) -> dict[str, Union[str, int]]: ...
+    def get_shutdown_message(self) -> dict[str, str | int]: ...

--- a/dispatcherd/registry.py
+++ b/dispatcherd/registry.py
@@ -3,7 +3,7 @@ import json
 import logging
 import threading
 import time
-from typing import Callable, Iterable, Optional, Set, Tuple, Union
+from typing import Callable, Iterable, Optional, Set, Tuple
 from uuid import uuid4
 
 from .config import LazySettings
@@ -31,7 +31,7 @@ class DispatcherMethod:
     def __init__(
         self,
         fn: DispatcherCallable,
-        queue: Union[Callable, str, None] = None,
+        queue: Callable | str | None = None,
         bind: bool = False,
         processor_options: Iterable[ProcessorParams] = (),
         **submission_defaults,
@@ -120,7 +120,7 @@ class DispatcherMethod:
         self,
         args: Optional[tuple] = None,
         kwargs: Optional[dict] = None,
-        queue: Union[str, Callable[..., str], None] = None,
+        queue: str | Callable[..., str] | None = None,
         uuid: Optional[str] = None,
         settings: LazySettings = global_settings,
         bind: bool = False,

--- a/dispatcherd/testing/subprocess.py
+++ b/dispatcherd/testing/subprocess.py
@@ -6,7 +6,6 @@ import sys
 import traceback
 from multiprocessing.context import BaseContext
 from types import ModuleType
-from typing import Union
 
 from .asyncio import adispatcher_service
 
@@ -22,7 +21,7 @@ class CommunicationItems:
     This will be passed in the call to the subprocess.
     """
 
-    def __init__(self, main_events: tuple[str], pool_events: tuple[str], context: Union[BaseContext, ModuleType]) -> None:
+    def __init__(self, main_events: tuple[str], pool_events: tuple[str], context: BaseContext | ModuleType) -> None:
         self.q_in: multiprocessing.Queue = context.Queue()
         self.q_out: multiprocessing.Queue = context.Queue()
         self.main_events = main_events

--- a/dispatcherd/utils.py
+++ b/dispatcherd/utils.py
@@ -1,6 +1,6 @@
 import importlib
 from enum import Enum
-from typing import Callable, Optional, Protocol, Type, Union, runtime_checkable
+from typing import Callable, Optional, Protocol, Type, runtime_checkable
 
 
 @runtime_checkable
@@ -11,7 +11,7 @@ class RunnableClass(Protocol):
 MODULE_METHOD_DELIMITER = '.'
 
 
-DispatcherCallable = Union[Callable, Type[RunnableClass]]
+DispatcherCallable = Callable | Type[RunnableClass]
 
 
 def resolve_callable(task: str) -> Optional[Callable]:

--- a/dispatcherd/worker/task.py
+++ b/dispatcherd/worker/task.py
@@ -5,7 +5,7 @@ import signal
 import sys
 import time
 import traceback
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from ..protocols import TaskWorker as TaskWorkerProtocol
 from ..registry import DispatcherMethodRegistry
@@ -223,10 +223,10 @@ class TaskWorker(TaskWorkerProtocol):
             "time_finish": time.time(),
         }
 
-    def get_ready_message(self) -> dict[str, Union[str, int]]:
+    def get_ready_message(self) -> dict[str, str | int]:
         """Message for traffic control, saying am entering the main work loop"""
         return {"worker": self.worker_id, "event": "ready"}
 
-    def get_shutdown_message(self) -> dict[str, Union[str, int]]:
+    def get_shutdown_message(self) -> dict[str, str | int]:
         """Message for traffic control, do not deliver any more mail to this address"""
         return {"worker": self.worker_id, "event": "shutdown"}


### PR DESCRIPTION
Use Python's native union type operator (|) instead of typing.Union across codebase. I can confirm all tests are passing locally after these changes:

>
============================================================= 221 passed, 62 warnings in 59.28s ==============================================================

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces typing.Union with the native | union operator and updates related type hints across brokers, control, protocols, producers, registry, utils, worker, tests.
> 
> - **Types**:
>   - Replace `typing.Union[...]` with native `|` unions across codebase.
>   - Update function/method signatures and protocol definitions to use `int | str`, `dict | str`, etc.
>   - Remove now-unused `Union` imports.
> - **Touched areas**:
>   - `dispatcherd/brokers/{noop.py,socket.py}`: broker interfaces (`aprocess_notify`, `apublish_message`, `process_notify`).
>   - `dispatcherd/control.py`: `_ingest_reply_payload`, `create_message`, and `DispatcherMain.process_message` types.
>   - `dispatcherd/protocols.py`: protocol method signatures and worker message shapes (`get_ready_message`, `get_shutdown_message`).
>   - `dispatcherd/producers/brokered.py`: `notify` signature.
>   - `dispatcherd/registry.py`: `DispatcherMethod` params and `apply_async` queue types.
>   - `dispatcherd/testing/subprocess.py`: `CommunicationItems` constructor param type.
>   - `dispatcherd/utils.py`: `DispatcherCallable` alias.
>   - `dispatcherd/worker/task.py`: worker message dict typings.
>   - `conftest.py`: test helper type annotations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f1ac93469eb3c532e4dd1bdbf55e7d82d49b070. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->