### PR TITLE
Add logs about postgres connection time, distinguish send-and-reply time

### DIFF
--- a/dispatcherd/brokers/pg_notify.py
+++ b/dispatcherd/brokers/pg_notify.py
@@ -143,6 +143,7 @@ class Broker(BrokerProtocol):
     async def aget_connection(self) -> psycopg.AsyncConnection:
         # Check if the cached async connection is either None or closed.
         if not self._async_connection or getattr(self._async_connection, "closed", 0) != 0:
+            start = time.perf_counter()
             if self._async_connection_factory:
                 factory = resolve_callable(self._async_connection_factory)
                 if not factory:
@@ -154,6 +155,7 @@ class Broker(BrokerProtocol):
             else:
                 raise RuntimeError('Could not construct async connection for lack of config or factory')
             self._async_connection = connection
+            logger.info('pg_notify async connection established in %.3f seconds', time.perf_counter() - start)
         assert self._async_connection is not None
         return self._async_connection
 
@@ -277,6 +279,7 @@ class Broker(BrokerProtocol):
     def get_connection(self) -> psycopg.Connection:
         # Check if the cached connection is either None or closed.
         if not self._sync_connection or getattr(self._sync_connection, "closed", 0) != 0:
+            start = time.perf_counter()
             if self._sync_connection_factory:
                 factory = resolve_callable(self._sync_connection_factory)
                 if not factory:
@@ -288,6 +291,7 @@ class Broker(BrokerProtocol):
             else:
                 raise RuntimeError('Could not construct connection for lack of config or factory')
             self._sync_connection = connection
+            logger.info('pg_notify sync connection established in %.3f seconds', time.perf_counter() - start)
         assert self._sync_connection is not None
         return self._sync_connection
 


### PR DESCRIPTION
Fairly recently I pivoted to the idea that we can/should use pg_notify broker for purposes of debugging, and generally for control-and-reply commands (the later of which was inevitable anyway).

I know that eda-server has a couple of call-and-response items used for liveliness checks. However, doing local debugging I was seeing a lot of ~0.25 second times for control-and-reply round trip times. This is extremely concerning, because for what eda-server needs this for, those timings are not okay, not even a little bit.

But it turns out, it was a false alarm. Nonetheless, this needs a lot more delicacy than what we've been giving it. Here are some logs with this change in:

```
$ dispatcherctl running
DEBUG:dispatcherd.cli:Configured standard out logging at DEBUG level
INFO:dispatcherd.cli:Using config from file /home/arominge/repos/dispatcherd/dispatcher.yml
INFO:dispatcherd.brokers.pg_notify:pg_notify sync connection established in 0.221 seconds
INFO:dispatcherd.brokers.pg_notify:Set up pg_notify listening on channel 'reply_to_fad5c59e_17ff_4457_adcb_71f150905c64'
INFO:dispatcherd.brokers.pg_notify:Set up pg_notify listening on channel 'self_check_d459a613_b8fd_4247_80b7_4ce06ed62f3c'
DEBUG:dispatcherd.brokers.pg_notify:Sent pg_notify message of 83 chars as 1 chunk(s) to test_channel
DEBUG:dispatcherd.brokers.pg_notify:Starting listening for pg_notify notifications
INFO:awx.main.dispatch.control:control-and-reply running returned in 0.266 seconds (round-trip 0.002s)
- node_id: demo-server-a

```

Here's what's going on:
 - connecting to postgres takes ~0.2 seconds. Sometimes it takes 2 seconds. That's fine. Not our problem. People are generally familiar with the expense and no one expected it to be free.
 - The actual act of sending the message and getting a reply took 0.002 seconds. This is :100: percent :ok_hand: 

That doesn't mean that stuff won't get screwed up when deployed into actual code doing real work. If the control object is created and allowed to connect all on its lonesome, then it will incur the costs of connecting, unnecessarily. This can absolutely screw things up, and at some point it probably will.

Running the `dispatcherctl` on the CLI is going to have a human-noticeable delay due to connecting. That's okay! Because we didn't start out with a connection. However, if we need an `alive` command ran in a task to see what workers are available, that's probably not okay!

In any case, these are the logging changes we need so that when that screws up, we quickly sort out what's going on and how to fix it. Ping @Alex-Izquierdo @hsong-rh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add timing logs for pg_notify connection establishment and separate total vs round-trip timing for control-and-reply using perf_counter.
> 
> - **Logging & Timing**:
>   - **Postgres connections (`dispatcherd/brokers/pg_notify.py`)**:
>     - Log async and sync connection establishment durations using `time.perf_counter()`.
>   - **Control-and-reply (`dispatcherd/control.py`)**:
>     - Introduce `SyncBrokerCallbacks` to capture send start time.
>     - Switch to `time.perf_counter()` and log total elapsed and explicit round-trip time for `control_with_reply`.
>     - Use connected callback to publish and compute precise round-trip metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58291721074757e16863ceae4bbc1d62357e626b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->