### PR TITLE
Allow configuring worker in-task signal behavior

### DIFF
--- a/dispatcherd/factories.py
+++ b/dispatcherd/factories.py
@@ -130,7 +130,10 @@ SERIALIZED_TYPES = (int, str, dict, type(None), tuple, list, float, bool)
 
 
 def is_valid_annotation(annotation):
-    if get_origin(annotation):
+    origin = get_origin(annotation)
+    if origin is Literal:
+        return all(isinstance(arg, SERIALIZED_TYPES) for arg in get_args(annotation))
+    if origin:
         for arg in get_args(annotation):
             if not is_valid_annotation(arg):
                 return False

--- a/docs/config.md
+++ b/docs/config.md
@@ -125,6 +125,10 @@ to limit how long the queue read blocks before re-evaluating shutdown criteria.
 it will be retired. The default is 4 hours. Setting it to `null` disables
 automatic retirement, which is not recommended for long-running services.
 
+`shutdown_task_grace_period` controls how long the pool waits (in seconds) after
+issuing a stop message before canceling active tasks. Use `0` to keep the
+previous behavior of canceling immediately.
+
 #### Producers
 
 These are "producers of tasks" in the dispatcherd service.

--- a/docs/config.md
+++ b/docs/config.md
@@ -166,3 +166,7 @@ used for testing this feature.
 The `idle_timeout` is a number of seconds which determines how long
 after no new tasks are received that the `on_idle` callback will be called.
 That can be useful for connection keep-alive work and such.
+
+`task_signal_handling` controls how SIGINT/SIGTERM are handled while a task is
+running. Supported values are `default` (use Python's default handler),
+`dispatcher_exit` (raise `DispatcherExit`), and `noop` (ignore the signal).

--- a/docs/signal_guidance.md
+++ b/docs/signal_guidance.md
@@ -10,9 +10,10 @@ interplay is relevant to app developers embeding dispatcherd.
   this to an in-flight worker when a timeout or cancel or manual cancel occurs. The worker raises
   `DispatcherCancel`, so user code must let that exception propagate if it wants cancel requests
   to succeed while keeping the worker alive for future tasks.
-- **SIGINT** and **SIGTERM** – default python behavior while tasks are running.
-  Idle workers process these signals and exit, which is necessary when the signal
-  is given to the entire process group for shutdown.
+- **SIGINT** and **SIGTERM** – default python behavior while tasks are running unless
+  you override `task_signal_handling` in worker config. Idle workers process these
+  signals and exit, which is necessary when the signal is given to the entire
+  process group for shutdown.
 
 ### DispatcherCancel vs DispatcherExit
 
@@ -49,7 +50,8 @@ interplay is relevant to app developers embeding dispatcherd.
 
 - **Configure SIGINT/SIGTERM when your task starts.** Use your task’s `pre_task` hook (or
   equivalent entrypoint) to set application-specific handlers. Dispatcherd restores default
-  handlers just before `pre_task` runs and reinstalls idle-mode handlers after the task finishes.
+  handlers just before `pre_task` runs (or uses your configured `task_signal_handling`)
+  and reinstalls idle-mode handlers after the task finishes.
 - **Never touch SIGUSR1.** The dispatcher depends on it for cancels/timeouts; overriding it
   breaks task cancel semantics.
 - **Use `DispatcherCancel` for timeouts.** Treat it like any other exception that

--- a/schema.json
+++ b/schema.json
@@ -37,7 +37,8 @@
       "worker_stop_wait": "<class 'float'>",
       "worker_removal_wait": "<class 'float'>",
       "worker_max_lifetime_seconds": "float | None",
-      "results_read_timeout": "float | None"
+      "results_read_timeout": "float | None",
+      "shutdown_task_grace_period": "<class 'float'>"
     },
     "main_kwargs": {
       "node_id": "str | None",

--- a/schema.json
+++ b/schema.json
@@ -58,7 +58,8 @@
   "worker": {
     "worker_kwargs": {
       "worker_id": "<class 'int'>",
-      "idle_timeout": "<class 'int'>"
+      "idle_timeout": "<class 'int'>",
+      "task_signal_handling": "typing.Literal['default', 'dispatcher_exit', 'noop']"
     },
     "worker_cls": "typing.Any"
   }


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcherd/issues/210

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces configurable worker signal behavior and improves pool shutdown sequencing.
> 
> - **Worker signals**: `WorkerSignalHandler` adds `task_signal_handling` (`default` | `dispatcher_exit` | `noop`) to control SIGINT/SIGTERM handling during tasks; `TaskWorker` accepts and forwards this option.
> - **Pool shutdown**: `WorkerPool` adds `shutdown_task_grace_period` and a new shutdown flow: signal workers to stop, optionally wait for a grace period, cancel remaining active tasks, then stop/cleanup workers and finish results processing.
> - **Schema/Docs**: `schema.json` and `docs/config.md` updated for new options; new `docs/signal_guidance.md` explains signal semantics.
> - **Type/schema gen**: `is_valid_annotation` now validates `Literal[...]` argument types.
> - **Tests**: new unit tests cover signal handling modes and validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5dc25aeada060cbcd25924cfc73e3bc3890f6072. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->