### PR TITLE
Add debugging commands related to memory leaks

### DIFF
--- a/dispatcherd/service/control_tasks.py
+++ b/dispatcherd/service/control_tasks.py
@@ -227,7 +227,7 @@ async def memory_offenders(dispatcher: DispatcherMain, data: dict) -> dict[str, 
             help: Group by type name or module-qualified class name.
     """
     limit = data.get('limit', 10)
-    if not isinstance(limit, int):
+    if type(limit) is not int:
         limit = 10
     group_by = data.get('group_by', 'type')
     if group_by not in ('type', 'class'):

--- a/dispatcherd/service/control_tasks.py
+++ b/dispatcherd/service/control_tasks.py
@@ -1,10 +1,26 @@
 import asyncio
+import gc
 import io
 import logging
 
 from ..protocols import DispatcherMain
+from . import memory_inspect
 
-__all__ = ['running', 'cancel', 'alive', 'aio_tasks', 'workers', 'producers', 'metrics', 'main', 'status', 'chunks', 'set_log_level']
+__all__ = [
+    'running',
+    'cancel',
+    'alive',
+    'aio_tasks',
+    'workers',
+    'producers',
+    'metrics',
+    'main',
+    'status',
+    'chunks',
+    'memory',
+    'memory_offenders',
+    'set_log_level',
+]
 
 
 logger = logging.getLogger(__name__)
@@ -186,11 +202,37 @@ async def status(dispatcher: DispatcherMain, data: dict) -> dict:
     """Information from all other non-destructive commands nested in a sub-dictionary"""
     ret = {}
     for command in __all__:
-        if command in ('cancel', 'alive', 'status', 'run', 'set_log_level'):
+        if command in ('cancel', 'alive', 'status', 'run', 'set_log_level', 'memory_offenders'):
             continue
         control_method = globals()[command]
         ret[command] = await control_method(dispatcher=dispatcher, data={})
     return ret
+
+
+async def memory(dispatcher: DispatcherMain, data: dict) -> dict[str, int]:
+    """Return memory-related information for the dispatcher process."""
+    return {'objects': len(gc.get_objects())}
+
+
+async def memory_offenders(dispatcher: DispatcherMain, data: dict) -> dict[str, object]:
+    """Return a list of object types with the largest shallow memory usage.
+
+    Control Args:
+        limit:
+            type: int
+            help: Maximum number of offender types to return.
+        group_by:
+            type: str
+            choices: [type, class]
+            help: Group by type name or module-qualified class name.
+    """
+    limit = data.get('limit', 10)
+    if not isinstance(limit, int):
+        limit = 10
+    group_by = data.get('group_by', 'type')
+    if group_by not in ('type', 'class'):
+        group_by = 'type'
+    return memory_inspect.get_object_size_stats(limit=limit, group_by=group_by)
 
 
 def _coerce_log_level(level_name: str | None) -> int | None:

--- a/dispatcherd/service/memory_inspect.py
+++ b/dispatcherd/service/memory_inspect.py
@@ -7,9 +7,9 @@ class _Offender(TypedDict):
     count: int
     size_bytes: int
     type: str
+    class_: NotRequired[str]
     module: NotRequired[str]
     qualname: NotRequired[str]
-    class_: NotRequired[str]
 
 
 def _class_identifier(obj: object) -> tuple[str, str, str]:
@@ -54,7 +54,9 @@ def get_object_size_stats(limit: int = 10, group_by: str = 'type') -> dict[str, 
     offenders = []
     for entry in totals.values():
         if 'class_' in entry:
-            offenders.append({**entry, 'class': entry['class_']})
+            trimmed = {key: value for key, value in entry.items() if key != 'class_'}
+            trimmed['class'] = entry['class_']
+            offenders.append(trimmed)
         else:
             offenders.append(dict(entry))
     offenders.sort(key=lambda item: (item['size_bytes'], item['count'], item['type']), reverse=True)

--- a/dispatcherd/service/memory_inspect.py
+++ b/dispatcherd/service/memory_inspect.py
@@ -1,0 +1,66 @@
+import gc
+import sys
+from typing import NotRequired, TypedDict
+
+
+class _Offender(TypedDict):
+    count: int
+    size_bytes: int
+    type: str
+    module: NotRequired[str]
+    qualname: NotRequired[str]
+    class_: NotRequired[str]
+
+
+def _class_identifier(obj: object) -> tuple[str, str, str]:
+    type_obj = type(obj)
+    module = getattr(type_obj, '__module__', 'builtins')
+    qualname = getattr(type_obj, '__qualname__', type_obj.__name__)
+    return module, qualname, type_obj.__name__
+
+
+def get_object_size_stats(limit: int = 10, group_by: str = 'type') -> dict[str, object]:
+    """Return shallow size totals grouped by object type or class."""
+    objects = gc.get_objects()
+    totals: dict[str, _Offender] = {}
+    by_class = group_by == 'class'
+
+    for obj in objects:
+        module, qualname, type_name = _class_identifier(obj)
+        if by_class:
+            key = f'{module}.{qualname}'
+        else:
+            key = type_name
+
+        try:
+            size = sys.getsizeof(obj)
+        except Exception:
+            continue
+
+        entry = totals.get(key)
+        if entry is None:
+            entry = {'count': 0, 'size_bytes': 0, 'type': type_name}
+            if by_class:
+                entry['module'] = module
+                entry['qualname'] = qualname
+                entry['class_'] = key
+            else:
+                entry['type'] = type_name
+            totals[key] = entry
+
+        entry['count'] += 1
+        entry['size_bytes'] += size
+
+    offenders = []
+    for entry in totals.values():
+        if 'class_' in entry:
+            offenders.append({**entry, 'class': entry['class_']})
+        else:
+            offenders.append(dict(entry))
+    offenders.sort(key=lambda item: (item['size_bytes'], item['count'], item['type']), reverse=True)
+
+    return {
+        'total_objects': len(objects),
+        'group_by': 'class' if by_class else 'type',
+        'offenders': offenders[: max(limit, 0)],
+    }

--- a/dispatcherd/service/metrics.py
+++ b/dispatcherd/service/metrics.py
@@ -1,4 +1,5 @@
 import asyncio
+import gc
 import logging
 from typing import Any, Generator, Optional
 
@@ -42,6 +43,11 @@ def metrics_data(dispatcher: DispatcherMain) -> Generator[Metric, Any, Any]:
         'dispatcher_worker_count',
         'Number of workers running.',
         value=len(list(dispatcher.pool.workers)),
+    )
+    yield CounterMetricFamily(
+        'dispatcher_memory_objects_count',
+        'Number of GC-tracked objects in the dispatcher process.',
+        value=len(gc.get_objects()),
     )
 
 

--- a/dispatcherd/service/metrics.py
+++ b/dispatcherd/service/metrics.py
@@ -7,7 +7,7 @@ from typing import Any, Generator, Optional
 from prometheus_client import CollectorRegistry, generate_latest
 
 # For production of the metrics
-from prometheus_client.core import CounterMetricFamily
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 from prometheus_client.metrics_core import Metric
 from prometheus_client.registry import Collector
 
@@ -44,7 +44,7 @@ def metrics_data(dispatcher: DispatcherMain) -> Generator[Metric, Any, Any]:
         'Number of workers running.',
         value=len(list(dispatcher.pool.workers)),
     )
-    yield CounterMetricFamily(
+    yield GaugeMetricFamily(
         'dispatcher_memory_objects_count',
         'Number of GC-tracked objects in the dispatcher process.',
         value=len(gc.get_objects()),

--- a/tests/unit/test_control_tasks.py
+++ b/tests/unit/test_control_tasks.py
@@ -57,6 +57,14 @@ def test_memory_reports_object_count(monkeypatch):
 
 def test_memory_offenders_uses_helper(monkeypatch):
     expected = {'total_objects': 5, 'offenders': [{'type': 'X', 'count': 5, 'size_bytes': 40}]}
-    monkeypatch.setattr(control_tasks.memory_inspect, 'get_object_size_stats', lambda limit=10, group_by='type': expected)
+    received = {}
+
+    def fake_get_object_size_stats(*, limit=10, group_by='type'):
+        received['limit'] = limit
+        received['group_by'] = group_by
+        return expected
+
+    monkeypatch.setattr(control_tasks.memory_inspect, 'get_object_size_stats', fake_get_object_size_stats)
     result = asyncio.run(control_tasks.memory_offenders(dispatcher=None, data={'limit': 5, 'group_by': 'class'}))
+    assert received == {'limit': 5, 'group_by': 'class'}
     assert result == expected

--- a/tests/unit/test_control_tasks.py
+++ b/tests/unit/test_control_tasks.py
@@ -47,3 +47,16 @@ def test_set_log_level_integer(dispatcherd_logger):
     result = asyncio.run(control_tasks.set_log_level(dispatcher=None, data={'level': 30}))
     assert dispatcherd_logger.level == logging.WARNING
     assert result == {'logger': 'dispatcherd', 'level': 'WARNING', 'previous_level': 'ERROR'}
+
+
+def test_memory_reports_object_count(monkeypatch):
+    monkeypatch.setattr(control_tasks.gc, 'get_objects', lambda: [object(), object(), object()])
+    result = asyncio.run(control_tasks.memory(dispatcher=None, data={}))
+    assert result == {'objects': 3}
+
+
+def test_memory_offenders_uses_helper(monkeypatch):
+    expected = {'total_objects': 5, 'offenders': [{'type': 'X', 'count': 5, 'size_bytes': 40}]}
+    monkeypatch.setattr(control_tasks.memory_inspect, 'get_object_size_stats', lambda limit=10, group_by='type': expected)
+    result = asyncio.run(control_tasks.memory_offenders(dispatcher=None, data={'limit': 5, 'group_by': 'class'}))
+    assert result == expected


### PR DESCRIPTION
Fixes https://github.com/ansible/dispatcherd/issues/209

Demo

```
(awx) arominge@arominge-thinkpadp16vgen1:~/repos/dispatcherd$ dispatcherctl memory
DEBUG:dispatcherd.cli:Configured standard out logging at DEBUG level
INFO:dispatcherd.cli:Using config from file /home/arominge/repos/dispatcherd/dispatcher.yml
INFO:dispatcherd.brokers.socket:Publishing socket message len=82 via existing connection
INFO:awx.main.dispatch.control:control-and-reply memory returned in 0.004 seconds (round-trip 0.003s)
- node_id: demo-server-a
  objects: 41914

(awx) arominge@arominge-thinkpadp16vgen1:~/repos/dispatcherd$ dispatcherctl memory_offenders
DEBUG:dispatcherd.cli:Configured standard out logging at DEBUG level
INFO:dispatcherd.cli:Using config from file /home/arominge/repos/dispatcherd/dispatcher.yml
INFO:dispatcherd.brokers.socket:Publishing socket message len=92 via existing connection
INFO:awx.main.dispatch.control:control-and-reply memory_offenders returned in 0.022 seconds (round-trip 0.021s)
- group_by: type
  node_id: demo-server-a
  offenders:
  - count: 4345
    size_bytes: 1956976
    type: dict
  - count: 1423
    size_bytes: 1808360
    type: type
  - count: 9245
    size_bytes: 1405240
    type: function
  - count: 501
    size_bytes: 831864
    type: _ProtocolMeta
  - count: 6927
    size_bytes: 440664
    type: tuple
  - count: 2717
    size_bytes: 217360
    type: ReferenceType
  - count: 1796
    size_bytes: 209328
    type: list
  - count: 138
    size_bytes: 196080
    type: ABCMeta
  - count: 229
    size_bytes: 195384
    type: set
  - count: 684
    size_bytes: 181792
    type: frozenset
  total_objects: 41919

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces memory observability to dispatcher.
> 
> - Adds `memory` control to report GC-tracked object count and `memory_offenders` to return top shallow-size object groups with `limit` and `group_by` (type|class) options
> - New `memory_inspect` helper computes grouped shallow sizes via `gc.get_objects()` and `sys.getsizeof`
> - Extends Prometheus with `dispatcher_memory_objects_count` Gauge
> - Updates `status` aggregation to skip `memory_offenders` and adds targeted unit/integration tests for the new controls
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b81fdf755eb06ec08336bfa0da89fb392d32a49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->