### PR TITLE
Try to support py 3.11 temporarily again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         py_version:
+          - '3.11'
           - '3.12'
           - '3.13'
           - '3.14'

--- a/asyncio_tests/integration/conftest.py
+++ b/asyncio_tests/integration/conftest.py
@@ -4,6 +4,6 @@ import pytest
 
 
 @pytest.fixture
-def python312():
-    if sys.version_info < (3, 12):
-        pytest.skip("test requires python 3.12")
+def python311():
+    if sys.version_info < (3, 11):
+        pytest.skip("test requires python 3.11")

--- a/asyncio_tests/integration/test_main.py
+++ b/asyncio_tests/integration/test_main.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import sys
 import time
 
 import pytest
@@ -292,7 +293,8 @@ async def test_tasks_are_named(apg_dispatcher, python311):
         if task is current_task:
             continue
         task_name = task.get_name()
-        assert not task_name.startswith('Task-'), _stack_from_task(task)
+        if sys.version_info >= (3, 12):
+            assert not task_name.startswith('Task-'), _stack_from_task(task)
 
     apg_dispatcher.shared.exit_event.set()
     await wait_task

--- a/asyncio_tests/integration/test_main.py
+++ b/asyncio_tests/integration/test_main.py
@@ -284,7 +284,7 @@ async def test_scale_up(apg_dispatcher, test_settings):
 
 
 @pytest.mark.asyncio
-async def test_tasks_are_named(apg_dispatcher, python312):
+async def test_tasks_are_named(apg_dispatcher, python311):
     wait_task = asyncio.create_task(apg_dispatcher.main_loop_wait(), name='this_is_for_test')
 
     current_task = asyncio.current_task()

--- a/asyncio_tests/integration/test_signal_handling.py
+++ b/asyncio_tests/integration/test_signal_handling.py
@@ -54,7 +54,7 @@ async def test_sigusr1_cancel_avoids_sigterm(apg_dispatcher, pg_control, test_se
     assert canceled_info, f"Missing worker data: {canceled_info}"
 
     # We'll search for any subdict that has 'uuid': our expected value
-    (worker_key, worker_data) = list(canceled_info.items())[0]
+    worker_key, worker_data = list(canceled_info.items())[0]
     assert worker_data["uuid"] == uuid_val
 
     # Check that 1 task was canceled, and no SIGTERM printout

--- a/asyncio_tests/integration/test_socket_use.py
+++ b/asyncio_tests/integration/test_socket_use.py
@@ -87,7 +87,7 @@ async def test_simple_control_and_reply(asock_dispatcher, sock_control):
 
 
 @pytest.mark.asyncio
-async def test_socket_tasks_are_named(asock_dispatcher, sock_control, python312):
+async def test_socket_tasks_are_named(asock_dispatcher, sock_control, python311):
     loop = asyncio.get_event_loop()
 
     def aio_tasks_cmd():

--- a/asyncio_tests/integration/test_socket_use.py
+++ b/asyncio_tests/integration/test_socket_use.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import sys
 from typing import AsyncIterator, Callable
 
 import pytest
@@ -102,4 +103,5 @@ async def test_socket_tasks_are_named(asock_dispatcher, sock_control, python311)
     for task_name, task_stuff in data.items():
         if task_name == current_task_name:
             continue
-        assert not task_name.startswith('Task-'), task_stuff['stack']
+        if sys.version_info >= (3, 12):
+            assert not task_name.startswith('Task-'), task_stuff['stack']

--- a/dispatcherd/worker/task.py
+++ b/dispatcherd/worker/task.py
@@ -21,10 +21,10 @@ class WorkerSignalHandler:
         self.worker_id = worker_id
         self.enter_idle_mode()
 
-    def task_cancel(self, *args, **kwargs) -> None:  # type:ignore[no-untyped-def]
+    def task_cancel(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         raise DispatcherCancel
 
-    def exit_gracefully(self, *args, **kwargs) -> None:  # type:ignore[no-untyped-def]
+    def exit_gracefully(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         logger.info(f'Worker {self.worker_id} received worker process exit signal')
         self.kill_now = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,7 +12,7 @@ sonar.tests=tests
 
 # Python specific settings
 sonar.language=py
-sonar.python.version=3.12,3.13,3.14
+sonar.python.version=3.11,3.12,3.13,3.14
 
 # Coverage Report Location
 sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
We might need this again, TBD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores compatibility with Python 3.11 across CI and tooling, and adjusts tests accordingly.
> 
> - CI: add `3.11` to GitHub Actions matrix in `.github/workflows/ci.yml`
> - Packaging/metadata: add classifier `Python :: 3.11` in `pyproject.toml`; update Sonar config `sonar-project.properties` to include `3.11`
> - Tests: rename fixture to `python311` and require `>=3.11`; gate task name assertions behind `sys.version_info >= (3, 12)` in `asyncio_tests/integration/test_main.py` and `test_socket_use.py`
> - Minor fixes: tuple unpacking cleanup in `test_signal_handling.py`; spacing in type ignore comments in `dispatcherd/worker/task.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d5404563a776c949e21b0efde7b447a836e4c10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->