### PR TITLE
AAP-66379 Fix failure to scale-down bug and increase scale-down speed

### DIFF
--- a/asyncio_tests/unit/service/conftest.py
+++ b/asyncio_tests/unit/service/conftest.py
@@ -1,6 +1,5 @@
 import queue
 from typing import Callable
-from unittest import mock
 
 import pytest
 

--- a/asyncio_tests/unit/service/conftest.py
+++ b/asyncio_tests/unit/service/conftest.py
@@ -8,6 +8,14 @@ from dispatcherd.service.pool import WorkerPool
 from dispatcherd.service.process import ProcessManager
 
 
+def fill_and_check_scale_down(pool: WorkerPool) -> bool:
+    """Test helper: fill the usage tracker with current pool state and check if scale-down is warranted."""
+    worker_ct = len([w for w in pool.workers if w.counts_for_capacity])
+    demand_ct = pool.active_task_ct()
+    pool.usage_tracker.fill_unknown_usage(worker_ct, demand_ct)
+    return pool.usage_tracker.should_scale_down(worker_ct, demand_ct)
+
+
 class FakeProcess:
     """A stand-in for ProcessProxy that requires no multiprocessing resources.
 

--- a/asyncio_tests/unit/service/conftest.py
+++ b/asyncio_tests/unit/service/conftest.py
@@ -1,4 +1,6 @@
+import queue
 from typing import Callable
+from unittest import mock
 
 import pytest
 
@@ -7,13 +9,122 @@ from dispatcherd.service.pool import WorkerPool
 from dispatcherd.service.process import ProcessManager
 
 
+class FakeProcess:
+    """A stand-in for ProcessProxy that requires no multiprocessing resources.
+
+    Provides the same interface as ProcessProxy (pid, is_alive, start, join,
+    kill, exitcode, message_queue) but backed by a plain queue.Queue and
+    simple flags.  No subprocess is created or forked.
+    """
+
+    def __init__(self) -> None:
+        self.message_queue: queue.Queue = queue.Queue()
+        self._started = False
+
+    def start(self) -> None:
+        self._started = True
+
+    def join(self, timeout: int | None = None) -> None:
+        pass
+
+    @property
+    def pid(self) -> int | None:
+        return None
+
+    def exitcode(self) -> int | None:
+        return 0
+
+    def is_alive(self) -> bool:
+        return False
+
+    def kill(self) -> None:
+        pass
+
+    def terminate(self) -> None:
+        pass
+
+
+class FakeProcessManager:
+    """A stand-in for ProcessManager that creates FakeProcess instances.
+
+    No multiprocessing queues or real subprocesses are allocated.
+    """
+
+    def create_process(self, **kwargs) -> FakeProcess:
+        return FakeProcess()
+
+    def has_shutdown(self) -> bool:
+        return False
+
+
+class FakeWorkerPool(WorkerPool):
+    """A WorkerPool that puts newly created workers straight into 'ready' status.
+
+    Workers are real PoolWorker instances backed by FakeProcess objects (via
+    FakeProcessManager), so all properties and bookkeeping methods work
+    unchanged.  The only difference is that up() sets the worker to 'ready'
+    immediately, skipping the initialized -> spawned -> starting -> ready
+    lifecycle that requires a real subprocess.
+    """
+
+    async def up(self) -> int:
+        worker_id = await super().up()
+        self.workers.get_by_id(worker_id).status = 'ready'
+        return worker_id
+
+
 @pytest.fixture
 def pool_factory(test_settings) -> Callable[..., WorkerPool]:
+    """Create a WorkerPool backed by a real ProcessManager.
+
+    Workers created via pool.up() are real PoolWorker instances wrapping
+    ProcessProxy objects.  No subprocess is forked until worker.start() is
+    called (by manage_new_workers), but the ProcessManager does allocate
+    multiprocessing queues.
+
+    Use this when the test needs:
+    - Real ProcessManager queues (read_results_forever, start_working, shutdown)
+    - Worker lifecycle states (initialized -> spawned -> starting -> ready)
+    - Subprocess error handling (worker.start() failures)
+
+    For tests that only exercise pool-level scaling, scheduling, or status
+    logic, prefer fake_pool_factory instead.
+    """
+
     def _factory(**kwargs_overrides) -> WorkerPool:
         pm = ProcessManager(settings=test_settings)
         kwargs = dict(process_manager=pm, min_workers=5, max_workers=5, shared=SharedAsyncObjects())
         kwargs.update(kwargs_overrides)
         pool = WorkerPool(**kwargs)
+        return pool
+
+    return _factory
+
+
+@pytest.fixture
+def fake_pool_factory() -> Callable[..., FakeWorkerPool]:
+    """Create a FakeWorkerPool backed by FakeProcessManager.
+
+    Workers created via pool.up() are real PoolWorker instances backed by
+    FakeProcess objects, immediately set to 'ready' status.  No subprocess
+    is created or forked, and no multiprocessing queues are allocated.
+
+    Use this for tests that exercise pool-level logic such as:
+    - Scale-up / scale-down decisions
+    - Task dispatching and scheduling
+    - Status data reporting
+
+    Use the real pool_factory when you need:
+    - Real ProcessManager queues (read_results_forever, start_working, shutdown)
+    - Worker lifecycle states (initialized -> spawned -> starting -> ready)
+    - Subprocess error handling (worker.start() failures)
+    """
+
+    def _factory(**kwargs_overrides) -> FakeWorkerPool:
+        pm = FakeProcessManager()
+        kwargs = dict(process_manager=pm, min_workers=5, max_workers=5, shared=SharedAsyncObjects())
+        kwargs.update(kwargs_overrides)
+        pool = FakeWorkerPool(**kwargs)
         return pool
 
     return _factory

--- a/asyncio_tests/unit/service/conftest.py
+++ b/asyncio_tests/unit/service/conftest.py
@@ -1,0 +1,19 @@
+from typing import Callable
+
+import pytest
+
+from dispatcherd.service.asyncio_tasks import SharedAsyncObjects
+from dispatcherd.service.pool import WorkerPool
+from dispatcherd.service.process import ProcessManager
+
+
+@pytest.fixture
+def pool_factory(test_settings) -> Callable[..., WorkerPool]:
+    def _factory(**kwargs_overrides) -> WorkerPool:
+        pm = ProcessManager(settings=test_settings)
+        kwargs = dict(process_manager=pm, min_workers=5, max_workers=5, shared=SharedAsyncObjects())
+        kwargs.update(kwargs_overrides)
+        pool = WorkerPool(**kwargs)
+        return pool
+
+    return _factory

--- a/asyncio_tests/unit/service/test_pool.py
+++ b/asyncio_tests/unit/service/test_pool.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import pytest
 
+from asyncio_tests.unit.service.conftest import fill_and_check_scale_down
 from dispatcherd.service.asyncio_tasks import SharedAsyncObjects
 from dispatcherd.service.main import DispatcherMain
 from dispatcherd.service.pool import WorkerPool
@@ -173,11 +174,11 @@ async def test_scale_down_condition(fake_pool_factory):
     base = 1000.0
     # First tick fills tracker with idle timestamps
     with mock.patch('time.monotonic', return_value=base):
-        assert pool.should_scale_down() is False
+        assert fill_and_check_scale_down(pool) is False
 
     # After scaledown_wait, scale-down proceeds
     with mock.patch('time.monotonic', return_value=base + 100.0):
-        assert pool.should_scale_down() is True
+        assert fill_and_check_scale_down(pool) is True
         await pool.scale_workers()
     # Same number of workers but all surplus workers have been sent a stop signal
     assert len(pool.workers) == 3
@@ -256,8 +257,8 @@ async def test_dispatch_task_holds_management_lock_and_blocks_scaledown(fake_poo
 
     # Starting the task should have happened while the lock was held.
     assert lock_states == [True]
-    # Worker is busy (current_task set), so should_scale_down fills key 1 as blocked.
-    assert pool.should_scale_down() is False
+    # Worker is busy (current_task set), so fill_unknown_usage marks key 1 as blocked.
+    assert fill_and_check_scale_down(pool) is False
 
 
 @pytest.mark.asyncio

--- a/asyncio_tests/unit/service/test_pool.py
+++ b/asyncio_tests/unit/service/test_pool.py
@@ -179,9 +179,11 @@ async def test_scale_down_condition(fake_pool_factory):
     with mock.patch('time.monotonic', return_value=base + 100.0):
         assert pool.should_scale_down() is True
         await pool.scale_workers()
-    # Same number of workers but one worker has been sent a stop signal
+    # Same number of workers but all surplus workers have been sent a stop signal
     assert len(pool.workers) == 3
-    assert set([worker.status for worker in pool.workers]) == {'ready', 'stopping'}
+    statuses = [worker.status for worker in pool.workers]
+    assert statuses.count('stopping') == 2
+    assert statuses.count('ready') == 1
 
 
 @pytest.mark.asyncio

--- a/asyncio_tests/unit/service/test_pool.py
+++ b/asyncio_tests/unit/service/test_pool.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import multiprocessing
 import time
-from typing import Callable
 from unittest import mock
 
 import pytest
@@ -33,18 +32,6 @@ class _InstrumentedQueueWrapper:
 
     async def wait_for_reader(self) -> None:
         await self._reader_waiting.wait()
-
-
-@pytest.fixture
-def pool_factory(test_settings) -> Callable[..., WorkerPool]:
-    def _factory(**kwargs_overrides) -> WorkerPool:
-        pm = ProcessManager(settings=test_settings)
-        kwargs = dict(process_manager=pm, min_workers=5, max_workers=5, shared=SharedAsyncObjects())
-        kwargs.update(kwargs_overrides)
-        pool = WorkerPool(**kwargs)
-        return pool
-
-    return _factory
 
 
 @pytest.fixture

--- a/asyncio_tests/unit/service/test_pool.py
+++ b/asyncio_tests/unit/service/test_pool.py
@@ -154,9 +154,9 @@ async def test_initialized_and_ready_but_scale(pool_factory):
 
 
 @pytest.mark.asyncio
-async def test_scale_down_condition(pool_factory):
+async def test_scale_down_condition(fake_pool_factory):
     """You have 3 workers due to past demand, but work finished long ago. Should scale down."""
-    pool = pool_factory(min_workers=1, max_workers=3)
+    pool = fake_pool_factory(min_workers=1, max_workers=3)
 
     # Prepare for test by scaling up to the 3 max workers by adding demand
     pool.queuer.queued_messages = [{'task': 'waiting.task'} for i in range(3)]  # 3 tasks, 3 workers
@@ -231,9 +231,9 @@ async def test_scale_up_worker_should_not_be_immediately_eligible_for_scaledown(
 
 
 @pytest.mark.asyncio
-async def test_dispatch_task_holds_management_lock_and_blocks_scaledown(pool_factory):
+async def test_dispatch_task_holds_management_lock_and_blocks_scaledown(fake_pool_factory):
     """Dispatched work should start while holding the worker lock and block scale-down heuristics."""
-    pool = pool_factory(min_workers=1, max_workers=1)
+    pool = fake_pool_factory(min_workers=1, max_workers=1)
     worker_id = await pool.up()
     worker = pool.workers.get_by_id(worker_id)
     worker.status = 'ready'
@@ -260,9 +260,9 @@ async def test_dispatch_task_holds_management_lock_and_blocks_scaledown(pool_fac
 
 
 @pytest.mark.asyncio
-async def test_manage_workers_skips_scaledown_when_recently_scaled_up(pool_factory):
+async def test_manage_workers_skips_scaledown_when_recently_scaled_up(fake_pool_factory):
     """When scaling up we should avoid the scale-down pass until the new capacity is used."""
-    pool = pool_factory()
+    pool = fake_pool_factory()
     pool.scaledown_interval = 0.0
 
     async def fake_scale_workers():
@@ -310,8 +310,8 @@ async def test_shutdown_is_idepotent(pool_factory):
 
 
 @pytest.mark.asyncio
-async def test_auto_count_max_workers(pool_factory):
+async def test_auto_count_max_workers(fake_pool_factory):
     "Test max_workers is set to the number of CPUs if not set"
     cpu_count = multiprocessing.cpu_count()
-    pool = pool_factory(max_workers=None)
+    pool = fake_pool_factory(max_workers=None)
     assert pool.max_workers == cpu_count

--- a/asyncio_tests/unit/service/test_pool.py
+++ b/asyncio_tests/unit/service/test_pool.py
@@ -265,7 +265,9 @@ async def test_dispatch_task_holds_management_lock_and_blocks_scaledown(pool_fac
 
     # Starting the task should have happened while the lock was held and should block scale-down timers.
     assert lock_states == [True]
-    assert pool.last_used_by_ct[1] is None
+    from dispatcherd.service.pool import _SCALE_DOWN_BLOCKED
+
+    assert pool.last_used_by_ct[1] is _SCALE_DOWN_BLOCKED
     assert pool.should_scale_down() is False
 
 

--- a/asyncio_tests/unit/service/test_pool.py
+++ b/asyncio_tests/unit/service/test_pool.py
@@ -8,7 +8,7 @@ import pytest
 
 from dispatcherd.service.asyncio_tasks import SharedAsyncObjects
 from dispatcherd.service.main import DispatcherMain
-from dispatcherd.service.pool import WorkerPool, WorkerUsageTracker
+from dispatcherd.service.pool import WorkerPool
 from dispatcherd.service.process import ProcessManager
 
 
@@ -170,7 +170,9 @@ async def test_scale_down_condition(pool_factory):
 
     # Clear queue and set finished times to long ago
     pool.queuer.queued_messages = []  # queue has been fully worked through, no workers are busy
-    pool.usage_tracker._last_used_by_ct = {i: time.monotonic() - 120.0 for i in range(30)}  # all work finished 120 seconds ago
+    with mock.patch('time.monotonic', return_value=time.monotonic() - 120.0):
+        for i in range(30):
+            pool.usage_tracker.record_task_finish(i)
 
     # Outcome of this situation is expected to be a scale-down event
     assert pool.should_scale_down() is True
@@ -196,8 +198,9 @@ async def test_scale_up_worker_should_not_be_immediately_eligible_for_scaledown(
         worker.current_task = None
 
     idle_timestamp = time.monotonic() - 120.0
-    for i in range(existing_workers + 1):
-        pool.usage_tracker._last_used_by_ct[i] = idle_timestamp  # stale timestamp for a previous high-water mark
+    with mock.patch('time.monotonic', return_value=idle_timestamp):
+        for i in range(existing_workers + 1):
+            pool.usage_tracker.record_task_finish(i)
 
     # Queue pressure requires more workers, so scaling up should add one.
     pool.queuer.queued_messages = [{'task': 'waiting.task'} for _ in range(existing_workers + 1)]
@@ -237,7 +240,8 @@ async def test_dispatch_task_holds_management_lock_and_blocks_scaledown(pool_fac
     worker.current_task = None
 
     # Pretend the worker idled long enough that, without new work, scale-down is allowed.
-    pool.usage_tracker._last_used_by_ct[1] = time.monotonic() - 120.0
+    with mock.patch('time.monotonic', return_value=time.monotonic() - 120.0):
+        pool.usage_tracker.record_task_finish(1)
 
     lock_states: list[bool] = []
 
@@ -252,7 +256,6 @@ async def test_dispatch_task_holds_management_lock_and_blocks_scaledown(pool_fac
 
     # Starting the task should have happened while the lock was held and should block scale-down timers.
     assert lock_states == [True]
-    assert pool.usage_tracker._last_used_by_ct[1] is WorkerUsageTracker._SCALE_DOWN_BLOCKED
     assert pool.should_scale_down() is False
 
 

--- a/asyncio_tests/unit/service/test_pool.py
+++ b/asyncio_tests/unit/service/test_pool.py
@@ -236,7 +236,7 @@ async def test_dispatch_task_holds_management_lock_and_blocks_scaledown(fake_poo
     pool = fake_pool_factory(min_workers=1, max_workers=1)
     worker_id = await pool.up()
     worker = pool.workers.get_by_id(worker_id)
-    worker.status = 'ready'
+    assert worker.status == 'ready'
     worker.current_task = None
 
     # Pretend the worker idled long enough that, without new work, scale-down is allowed.

--- a/asyncio_tests/unit/service/test_pool.py
+++ b/asyncio_tests/unit/service/test_pool.py
@@ -164,19 +164,21 @@ async def test_scale_down_condition(fake_pool_factory):
         await pool.scale_workers()
     assert len(pool.workers) == 3
     for worker in pool.workers:
-        worker.status = 'ready'  # a lie, for test
         worker.current_task = None
     assert set([worker.status for worker in pool.workers]) == {'ready'}
 
-    # Clear queue and set finished times to long ago
-    pool.queuer.queued_messages = []  # queue has been fully worked through, no workers are busy
-    with mock.patch('time.monotonic', return_value=time.monotonic() - 120.0):
-        for i in range(30):
-            pool.usage_tracker.record_task_finish(i)
+    # Clear queue — no workers are busy
+    pool.queuer.queued_messages = []
 
-    # Outcome of this situation is expected to be a scale-down event
-    assert pool.should_scale_down() is True
-    await pool.scale_workers()
+    base = 1000.0
+    # First tick fills tracker with idle timestamps
+    with mock.patch('time.monotonic', return_value=base):
+        assert pool.should_scale_down() is False
+
+    # After scaledown_wait, scale-down proceeds
+    with mock.patch('time.monotonic', return_value=base + 100.0):
+        assert pool.should_scale_down() is True
+        await pool.scale_workers()
     # Same number of workers but one worker has been sent a stop signal
     assert len(pool.workers) == 3
     assert set([worker.status for worker in pool.workers]) == {'ready', 'stopping'}
@@ -197,10 +199,10 @@ async def test_scale_up_worker_should_not_be_immediately_eligible_for_scaledown(
         worker.status = 'ready'
         worker.current_task = None
 
+    # Pre-fill tracker with old idle timestamps so scale-down would normally be allowed
     idle_timestamp = time.monotonic() - 120.0
     with mock.patch('time.monotonic', return_value=idle_timestamp):
-        for i in range(existing_workers + 1):
-            pool.usage_tracker.record_task_finish(i)
+        pool.usage_tracker.fill_unknown_usage(worker_ct=existing_workers, running_ct=0)
 
     # Queue pressure requires more workers, so scaling up should add one.
     pool.queuer.queued_messages = [{'task': 'waiting.task'} for _ in range(existing_workers + 1)]
@@ -239,10 +241,6 @@ async def test_dispatch_task_holds_management_lock_and_blocks_scaledown(fake_poo
     assert worker.status == 'ready'
     worker.current_task = None
 
-    # Pretend the worker idled long enough that, without new work, scale-down is allowed.
-    with mock.patch('time.monotonic', return_value=time.monotonic() - 120.0):
-        pool.usage_tracker.record_task_finish(1)
-
     lock_states: list[bool] = []
 
     async def start_task_under_lock(message):
@@ -254,8 +252,9 @@ async def test_dispatch_task_holds_management_lock_and_blocks_scaledown(fake_poo
     message = {'uuid': 'task-123', 'task': 'demo'}
     await pool.dispatch_task(message)
 
-    # Starting the task should have happened while the lock was held and should block scale-down timers.
+    # Starting the task should have happened while the lock was held.
     assert lock_states == [True]
+    # Worker is busy (current_task set), so should_scale_down fills key 1 as blocked.
     assert pool.should_scale_down() is False
 
 

--- a/asyncio_tests/unit/service/test_pool.py
+++ b/asyncio_tests/unit/service/test_pool.py
@@ -8,7 +8,7 @@ import pytest
 
 from dispatcherd.service.asyncio_tasks import SharedAsyncObjects
 from dispatcherd.service.main import DispatcherMain
-from dispatcherd.service.pool import WorkerPool
+from dispatcherd.service.pool import WorkerPool, WorkerUsageTracker
 from dispatcherd.service.process import ProcessManager
 
 
@@ -170,7 +170,7 @@ async def test_scale_down_condition(pool_factory):
 
     # Clear queue and set finished times to long ago
     pool.queuer.queued_messages = []  # queue has been fully worked through, no workers are busy
-    pool.last_used_by_ct = {i: time.monotonic() - 120.0 for i in range(30)}  # all work finished 120 seconds ago
+    pool.usage_tracker._last_used_by_ct = {i: time.monotonic() - 120.0 for i in range(30)}  # all work finished 120 seconds ago
 
     # Outcome of this situation is expected to be a scale-down event
     assert pool.should_scale_down() is True
@@ -197,7 +197,7 @@ async def test_scale_up_worker_should_not_be_immediately_eligible_for_scaledown(
 
     idle_timestamp = time.monotonic() - 120.0
     for i in range(existing_workers + 1):
-        pool.last_used_by_ct[i] = idle_timestamp  # stale timestamp for a previous high-water mark
+        pool.usage_tracker._last_used_by_ct[i] = idle_timestamp  # stale timestamp for a previous high-water mark
 
     # Queue pressure requires more workers, so scaling up should add one.
     pool.queuer.queued_messages = [{'task': 'waiting.task'} for _ in range(existing_workers + 1)]
@@ -237,7 +237,7 @@ async def test_dispatch_task_holds_management_lock_and_blocks_scaledown(pool_fac
     worker.current_task = None
 
     # Pretend the worker idled long enough that, without new work, scale-down is allowed.
-    pool.last_used_by_ct[1] = time.monotonic() - 120.0
+    pool.usage_tracker._last_used_by_ct[1] = time.monotonic() - 120.0
 
     lock_states: list[bool] = []
 
@@ -252,9 +252,7 @@ async def test_dispatch_task_holds_management_lock_and_blocks_scaledown(pool_fac
 
     # Starting the task should have happened while the lock was held and should block scale-down timers.
     assert lock_states == [True]
-    from dispatcherd.service.pool import _SCALE_DOWN_BLOCKED
-
-    assert pool.last_used_by_ct[1] is _SCALE_DOWN_BLOCKED
+    assert pool.usage_tracker._last_used_by_ct[1] is WorkerUsageTracker._SCALE_DOWN_BLOCKED
     assert pool.should_scale_down() is False
 
 

--- a/asyncio_tests/unit/service/test_pool.py
+++ b/asyncio_tests/unit/service/test_pool.py
@@ -205,7 +205,7 @@ async def test_scale_up_worker_should_not_be_immediately_eligible_for_scaledown(
     # Pre-fill tracker with old idle timestamps so scale-down would normally be allowed
     idle_timestamp = time.monotonic() - 120.0
     with mock.patch('time.monotonic', return_value=idle_timestamp):
-        pool.usage_tracker.fill_unknown_usage(worker_ct=existing_workers, running_ct=0)
+        pool.usage_tracker.fill_unknown_usage(worker_ct=existing_workers, demand_ct=0)
 
     # Queue pressure requires more workers, so scaling up should add one.
     pool.queuer.queued_messages = [{'task': 'waiting.task'} for _ in range(existing_workers + 1)]

--- a/asyncio_tests/unit/service/test_pool_scaledown.py
+++ b/asyncio_tests/unit/service/test_pool_scaledown.py
@@ -178,6 +178,7 @@ async def test_status_data_includes_usage_diagnostics(fake_pool_factory):
         data = pool.get_status_data()
 
     assert data["worker_ct"] == 4
+    assert data["running_ct"] == 2
     assert data["usage"]["count"] == 4
 
     # Near worker_ct=4: keys [2..6]

--- a/asyncio_tests/unit/service/test_pool_scaledown.py
+++ b/asyncio_tests/unit/service/test_pool_scaledown.py
@@ -56,7 +56,7 @@ async def test_task_finish_enables_timely_scale_down(fake_pool_factory):
         assert pool.workers.get_by_id(worker_id).status == 'ready'
 
     base = 1000.0
-    # Simulate a task finishing — sets timestamp at running_ct
+    # Simulate a task finishing — sets timestamp at the current capacity key
     with patch('time.monotonic', return_value=base):
         pool.usage_tracker.record_task_finish(3)
 
@@ -146,7 +146,7 @@ async def test_blocked_entries_clear_when_load_drops(fake_pool_factory):
     for w in workers:
         w.current_task = None
 
-    # Next tick: running_ct=0, previously blocked keys become timestamps
+    # Next tick: demand_ct=0, previously blocked keys become timestamps
     with patch('time.monotonic', return_value=base + 1.0):
         assert fill_and_check_scale_down(pool) is False  # timestamps too recent
 
@@ -172,7 +172,7 @@ async def test_status_data_includes_usage_diagnostics(fake_pool_factory):
     await workers[1].start_task({'task': 'busy-2'})
 
     base = 1000.0
-    # Fill: running_ct=2, so keys 1-2 blocked, keys 3-4 idle
+    # Fill: demand_ct=2, so keys 1-2 blocked, keys 3-4 idle
     with patch('time.monotonic', return_value=base):
         fill_and_check_scale_down(pool)
 
@@ -205,7 +205,7 @@ async def test_status_data_near_worker_ct_shows_absent_keys(fake_pool_factory):
         assert pool.workers.get_by_id(worker_id).status == 'ready'
 
     # Fill only keys 1-2 (via fill with worker_ct=2)
-    pool.usage_tracker.fill_unknown_usage(worker_ct=2, running_ct=0)
+    pool.usage_tracker.fill_unknown_usage(worker_ct=2, demand_ct=0)
 
     data = pool.get_status_data()
     near = data["usage"]["near_worker_ct"]

--- a/asyncio_tests/unit/service/test_pool_scaledown.py
+++ b/asyncio_tests/unit/service/test_pool_scaledown.py
@@ -1,6 +1,5 @@
 # Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 # See also: tests/unit/service/test_usage_tracker.py for synchronous unit tests of WorkerUsageTracker
-import time
 from unittest.mock import patch
 
 import pytest
@@ -80,16 +79,13 @@ async def test_scale_down_cascade_to_min_workers(fake_pool_factory):
     with patch('time.monotonic', return_value=base):
         pool.should_scale_down()
 
-    # After scaledown_wait, cascade scales all the way down
+    # After scaledown_wait, a single scale_workers call retires all surplus
     with patch('time.monotonic', return_value=base + 100.0):
-        for _ in range(20):  # enough iterations to converge
-            await pool.scale_workers()
-            for w in pool.workers:
-                if w.status == 'stopping':
-                    w.status = 'retired'
-                    w.retired_at = time.monotonic()
+        await pool.scale_workers()
 
+    stopping = [w for w in pool.workers if w.status == 'stopping']
     capacity_workers = [w for w in pool.workers if w.counts_for_capacity]
+    assert len(stopping) == 9
     assert len(capacity_workers) == 1
 
 
@@ -120,8 +116,8 @@ async def test_scale_down_respects_active_load(fake_pool_factory):
         await pool.scale_workers()
 
     statuses = [w.status for w in pool.workers]
-    assert statuses.count('stopping') == 1
-    assert statuses.count('ready') == 4
+    assert statuses.count('stopping') == 2
+    assert statuses.count('ready') == 3
 
 
 @pytest.mark.asyncio

--- a/asyncio_tests/unit/service/test_pool_scaledown.py
+++ b/asyncio_tests/unit/service/test_pool_scaledown.py
@@ -1,15 +1,14 @@
 # Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 # See also: tests/unit/service/test_usage_tracker.py for synchronous unit tests of WorkerUsageTracker
 import time
+from unittest.mock import patch
 
 import pytest
-
-from dispatcherd.service.pool import WorkerUsageTracker
 
 
 @pytest.mark.asyncio
 async def test_scale_down_when_never_needed_this_many_workers(pool_factory):
-    """Core regression: if _last_used_by_ct has entries for counts 1-2 but NOT 3,
+    """Core regression: if usage tracker has entries for counts 1-2 but NOT 3,
     should_scale_down() must return True and scale_workers() must produce a stopping worker."""
     pool = pool_factory(min_workers=1, max_workers=10)
 
@@ -19,10 +18,9 @@ async def test_scale_down_when_never_needed_this_many_workers(pool_factory):
         pool.workers.get_by_id(worker_id).status = 'ready'
 
     # Only have entries for counts 1 and 2, NOT 3
-    pool.usage_tracker._last_used_by_ct = {
-        1: time.monotonic() - 120.0,
-        2: time.monotonic() - 120.0,
-    }
+    with patch('time.monotonic', return_value=time.monotonic() - 120.0):
+        pool.usage_tracker.record_task_finish(1)
+        pool.usage_tracker.record_task_finish(2)
 
     assert pool.should_scale_down() is True
     await pool.scale_workers()
@@ -32,7 +30,7 @@ async def test_scale_down_when_never_needed_this_many_workers(pool_factory):
 
 @pytest.mark.asyncio
 async def test_scale_down_blocked_by_sentinel(pool_factory):
-    """3 ready idle workers with _last_used_by_ct[3] set to the sentinel.
+    """3 ready idle workers with usage tracker recording active work at count 3.
     should_scale_down() must return False."""
     pool = pool_factory(min_workers=1, max_workers=10)
 
@@ -47,7 +45,7 @@ async def test_scale_down_blocked_by_sentinel(pool_factory):
 
 @pytest.mark.asyncio
 async def test_scale_down_cascade_through_gaps(pool_factory):
-    """10 ready idle workers, _last_used_by_ct only has entries for counts 1-5.
+    """10 ready idle workers, usage tracker only has entries for counts 1-5.
     Repeatedly calling scale_workers() should scale all the way down to min_workers=1."""
     pool = pool_factory(min_workers=1, max_workers=10)
 
@@ -56,7 +54,9 @@ async def test_scale_down_cascade_through_gaps(pool_factory):
         pool.workers.get_by_id(worker_id).status = 'ready'
 
     # Only populate entries for counts 1-5
-    pool.usage_tracker._last_used_by_ct = {i: time.monotonic() - 120.0 for i in range(1, 6)}
+    with patch('time.monotonic', return_value=time.monotonic() - 120.0):
+        for i in range(1, 6):
+            pool.usage_tracker.record_task_finish(i)
 
     # Repeatedly scale down, retiring stopped workers between calls
     for _ in range(20):  # enough iterations to converge
@@ -73,7 +73,7 @@ async def test_scale_down_cascade_through_gaps(pool_factory):
 
 @pytest.mark.asyncio
 async def test_scale_down_with_conflicting_stale_data(pool_factory):
-    """5 ready idle workers exercising all three states of _last_used_by_ct[5]:
+    """5 ready idle workers exercising all three states of usage tracking:
     sentinel (False), old timestamp (True), recent timestamp (False), absent key (True)."""
     pool = pool_factory(min_workers=1, max_workers=10)
 
@@ -86,21 +86,24 @@ async def test_scale_down_with_conflicting_stale_data(pool_factory):
     assert pool.should_scale_down() is False
 
     # State 2: old timestamp allows scale-down
-    pool.usage_tracker._last_used_by_ct[5] = time.monotonic() - 120.0
+    with patch('time.monotonic', return_value=time.monotonic() - 120.0):
+        pool.usage_tracker.record_task_finish(5)
     assert pool.should_scale_down() is True
 
     # State 3: recent timestamp blocks scale-down
-    pool.usage_tracker._last_used_by_ct[5] = time.monotonic()
+    pool.usage_tracker.record_task_finish(5)
     assert pool.should_scale_down() is False
 
-    # State 4: absent key allows scale-down
-    del pool.usage_tracker._last_used_by_ct[5]
+    # State 4: absent key allows scale-down (add a worker to exceed tracked counts)
+    worker_id = await pool.up()
+    pool.workers.get_by_id(worker_id).status = 'ready'
+    # Now worker_ct=6, no entry for 6 exists
     assert pool.should_scale_down() is True
 
 
 @pytest.mark.asyncio
 async def test_status_data_includes_last_used_diagnostics(pool_factory):
-    """Populate _last_used_by_ct with 6 entries mixing sentinels and timestamps.
+    """Populate usage tracker with 6 entries mixing sentinels and timestamps.
     Assert get_status_data() includes count, top5, and near-worker-ct with correct formatting."""
     pool = pool_factory(min_workers=1, max_workers=10)
 
@@ -109,17 +112,21 @@ async def test_status_data_includes_last_used_diagnostics(pool_factory):
         worker_id = await pool.up()
         pool.workers.get_by_id(worker_id).status = 'ready'
 
-    now = time.monotonic()
-    pool.usage_tracker._last_used_by_ct = {
-        1: now - 100.0,
-        2: now - 50.0,
-        3: WorkerUsageTracker._SCALE_DOWN_BLOCKED,
-        4: now - 10.0,
-        5: WorkerUsageTracker._SCALE_DOWN_BLOCKED,
-        6: now - 1.0,
-    }
+    base = 1000.0
+    with patch('time.monotonic', return_value=base):
+        pool.usage_tracker.record_task_finish(1)
+    with patch('time.monotonic', return_value=base + 50.0):
+        pool.usage_tracker.record_task_finish(2)
+    pool.usage_tracker.record_task_start(3)
+    with patch('time.monotonic', return_value=base + 90.0):
+        pool.usage_tracker.record_task_finish(4)
+    pool.usage_tracker.record_task_start(5)
+    with patch('time.monotonic', return_value=base + 99.0):
+        pool.usage_tracker.record_task_finish(6)
 
-    data = pool.get_status_data()
+    with patch('time.monotonic', return_value=base + 100.0):
+        data = pool.get_status_data()
+
     assert data["worker_ct"] == 4
     assert data["usage"]["count"] == 6
 
@@ -148,7 +155,7 @@ async def test_status_data_includes_last_used_diagnostics(pool_factory):
 
 @pytest.mark.asyncio
 async def test_status_data_near_worker_ct_shows_absent_keys(pool_factory):
-    """When _last_used_by_ct has no entries near the current worker count,
+    """When usage tracker has no entries near the current worker count,
     the near-worker-ct summary should show 'absent' for missing keys."""
     pool = pool_factory(min_workers=1, max_workers=10)
 
@@ -158,12 +165,12 @@ async def test_status_data_near_worker_ct_shows_absent_keys(pool_factory):
         pool.workers.get_by_id(worker_id).status = 'ready'
 
     # Only populate entries far from worker_ct=8
-    now = time.monotonic()
-    pool.usage_tracker._last_used_by_ct = {1: now - 100.0, 2: now - 50.0}
+    pool.usage_tracker.record_task_finish(1)
+    pool.usage_tracker.record_task_finish(2)
 
     data = pool.get_status_data()
     near = data["usage"]["near_worker_ct"]
-    # Keys [6..10] centered on worker_ct=8, none present in _last_used_by_ct
+    # Keys [6..10] centered on worker_ct=8, none present in usage tracker
     assert set(near.keys()) == {6, 7, 8, 9, 10}
     for k in near:
         assert near[k] == "absent"

--- a/asyncio_tests/unit/service/test_pool_scaledown.py
+++ b/asyncio_tests/unit/service/test_pool_scaledown.py
@@ -1,0 +1,145 @@
+# Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+import time
+from typing import Callable
+
+import pytest
+
+from dispatcherd.service.asyncio_tasks import SharedAsyncObjects
+from dispatcherd.service.pool import _SCALE_DOWN_BLOCKED, WorkerPool
+from dispatcherd.service.process import ProcessManager
+
+
+@pytest.fixture
+def pool_factory(test_settings) -> Callable[..., WorkerPool]:
+    def _factory(**kwargs_overrides) -> WorkerPool:
+        pm = ProcessManager(settings=test_settings)
+        kwargs = dict(process_manager=pm, min_workers=5, max_workers=5, shared=SharedAsyncObjects())
+        kwargs.update(kwargs_overrides)
+        pool = WorkerPool(**kwargs)
+        return pool
+
+    return _factory
+
+
+@pytest.mark.asyncio
+async def test_scale_down_when_never_needed_this_many_workers(pool_factory):
+    """Core regression: if last_used_by_ct has entries for counts 1-2 but NOT 3,
+    should_scale_down() must return True and scale_workers() must produce a stopping worker."""
+    pool = pool_factory(min_workers=1, max_workers=10)
+
+    # Create 3 ready idle workers
+    for _ in range(3):
+        worker_id = await pool.up()
+        pool.workers.get_by_id(worker_id).status = 'ready'
+
+    # Only have entries for counts 1 and 2, NOT 3
+    pool.last_used_by_ct = {
+        1: time.monotonic() - 120.0,
+        2: time.monotonic() - 120.0,
+    }
+
+    assert pool.should_scale_down() is True
+    await pool.scale_workers()
+    statuses = [w.status for w in pool.workers]
+    assert 'stopping' in statuses
+
+
+@pytest.mark.asyncio
+async def test_scale_down_blocked_by_sentinel(pool_factory):
+    """3 ready idle workers with last_used_by_ct[3] set to the sentinel.
+    should_scale_down() must return False."""
+    pool = pool_factory(min_workers=1, max_workers=10)
+
+    for _ in range(3):
+        worker_id = await pool.up()
+        pool.workers.get_by_id(worker_id).status = 'ready'
+
+    pool.last_used_by_ct[3] = _SCALE_DOWN_BLOCKED
+
+    assert pool.should_scale_down() is False
+
+
+@pytest.mark.asyncio
+async def test_scale_down_cascade_through_gaps(pool_factory):
+    """10 ready idle workers, last_used_by_ct only has entries for counts 1-5.
+    Repeatedly calling scale_workers() should scale all the way down to min_workers=1."""
+    pool = pool_factory(min_workers=1, max_workers=10)
+
+    for _ in range(10):
+        worker_id = await pool.up()
+        pool.workers.get_by_id(worker_id).status = 'ready'
+
+    # Only populate entries for counts 1-5
+    pool.last_used_by_ct = {i: time.monotonic() - 120.0 for i in range(1, 6)}
+
+    # Repeatedly scale down, retiring stopped workers between calls
+    for _ in range(20):  # enough iterations to converge
+        await pool.scale_workers()
+        # Mark stopping workers as retired so they no longer count for capacity
+        for w in pool.workers:
+            if w.status == 'stopping':
+                w.status = 'retired'
+                w.retired_at = time.monotonic()
+
+    capacity_workers = [w for w in pool.workers if w.counts_for_capacity]
+    assert len(capacity_workers) == 1
+
+
+@pytest.mark.asyncio
+async def test_scale_down_with_conflicting_stale_data(pool_factory):
+    """5 ready idle workers exercising all three states of last_used_by_ct[5]:
+    sentinel (False), old timestamp (True), recent timestamp (False), absent key (True)."""
+    pool = pool_factory(min_workers=1, max_workers=10)
+
+    for _ in range(5):
+        worker_id = await pool.up()
+        pool.workers.get_by_id(worker_id).status = 'ready'
+
+    # State 1: sentinel blocks scale-down
+    pool.last_used_by_ct[5] = _SCALE_DOWN_BLOCKED
+    assert pool.should_scale_down() is False
+
+    # State 2: old timestamp allows scale-down
+    pool.last_used_by_ct[5] = time.monotonic() - 120.0
+    assert pool.should_scale_down() is True
+
+    # State 3: recent timestamp blocks scale-down
+    pool.last_used_by_ct[5] = time.monotonic()
+    assert pool.should_scale_down() is False
+
+    # State 4: absent key allows scale-down
+    del pool.last_used_by_ct[5]
+    assert pool.should_scale_down() is True
+
+
+@pytest.mark.asyncio
+async def test_status_data_includes_last_used_diagnostics(pool_factory):
+    """Populate last_used_by_ct with 6 entries mixing sentinels and timestamps.
+    Assert get_status_data() includes count and top5 with correct formatting."""
+    pool = pool_factory(min_workers=1, max_workers=10)
+
+    now = time.monotonic()
+    pool.last_used_by_ct = {
+        1: now - 100.0,
+        2: now - 50.0,
+        3: _SCALE_DOWN_BLOCKED,
+        4: now - 10.0,
+        5: _SCALE_DOWN_BLOCKED,
+        6: now - 1.0,
+    }
+
+    data = pool.get_status_data()
+    assert data["last_used_by_ct_count"] == 6
+
+    top5 = data["last_used_by_ct_top5"]
+    # Top 5 highest keys: 6, 5, 4, 3, 2
+    assert set(top5.keys()) == {2, 3, 4, 5, 6}
+
+    # Sentinel entries show "blocked"
+    assert top5[3] == "blocked"
+    assert top5[5] == "blocked"
+
+    # Timestamp entries show seconds-ago as floats
+    assert isinstance(top5[2], float)
+    assert isinstance(top5[4], float)
+    assert isinstance(top5[6], float)

--- a/asyncio_tests/unit/service/test_pool_scaledown.py
+++ b/asyncio_tests/unit/service/test_pool_scaledown.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 
 import pytest
 
+from asyncio_tests.unit.service.conftest import fill_and_check_scale_down
+
 
 @pytest.mark.asyncio
 async def test_scale_down_idle_workers(fake_pool_factory):
@@ -18,11 +20,11 @@ async def test_scale_down_idle_workers(fake_pool_factory):
     base = 1000.0
     # First tick: fills keys 1-3 as idle timestamps — too recent to scale down
     with patch('time.monotonic', return_value=base):
-        assert pool.should_scale_down() is False
+        assert fill_and_check_scale_down(pool) is False
 
     # Second tick after scaledown_wait: timestamps are old enough
     with patch('time.monotonic', return_value=base + 100.0):
-        assert pool.should_scale_down() is True
+        assert fill_and_check_scale_down(pool) is True
         await pool.scale_workers()
     statuses = [w.status for w in pool.workers]
     assert 'stopping' in statuses
@@ -39,7 +41,7 @@ async def test_scale_down_blocked_by_active_work(fake_pool_factory):
         assert worker.status == 'ready'
         await worker.start_task({'task': 'busy'})
 
-    assert pool.should_scale_down() is False
+    assert fill_and_check_scale_down(pool) is False
 
 
 @pytest.mark.asyncio
@@ -61,7 +63,7 @@ async def test_task_finish_enables_timely_scale_down(fake_pool_factory):
     # Periodic fill hasn't run yet, but key 3 already has a timestamp
     # After scaledown_wait, scale-down proceeds without needing a prior fill tick
     with patch('time.monotonic', return_value=base + 100.0):
-        assert pool.should_scale_down() is True
+        assert fill_and_check_scale_down(pool) is True
 
 
 @pytest.mark.asyncio
@@ -77,7 +79,7 @@ async def test_scale_down_cascade_to_min_workers(fake_pool_factory):
     base = 1000.0
     # First tick: fill all keys as idle
     with patch('time.monotonic', return_value=base):
-        pool.should_scale_down()
+        fill_and_check_scale_down(pool)
 
     # After scaledown_wait, a single scale_workers call retires all surplus
     with patch('time.monotonic', return_value=base + 100.0):
@@ -108,11 +110,11 @@ async def test_scale_down_respects_active_load(fake_pool_factory):
     base = 1000.0
     # First tick: keys 1-3 blocked, keys 4-5 idle timestamps
     with patch('time.monotonic', return_value=base):
-        assert pool.should_scale_down() is False
+        assert fill_and_check_scale_down(pool) is False
 
     # After scaledown_wait: surplus keys aged out, scale down from 5
     with patch('time.monotonic', return_value=base + 100.0):
-        assert pool.should_scale_down() is True
+        assert fill_and_check_scale_down(pool) is True
         await pool.scale_workers()
 
     statuses = [w.status for w in pool.workers]
@@ -138,7 +140,7 @@ async def test_blocked_entries_clear_when_load_drops(fake_pool_factory):
 
     base = 1000.0
     with patch('time.monotonic', return_value=base):
-        assert pool.should_scale_down() is False  # all blocked
+        assert fill_and_check_scale_down(pool) is False  # all blocked
 
     # Tasks finish — clear current_task to simulate completion
     for w in workers:
@@ -146,11 +148,11 @@ async def test_blocked_entries_clear_when_load_drops(fake_pool_factory):
 
     # Next tick: running_ct=0, previously blocked keys become timestamps
     with patch('time.monotonic', return_value=base + 1.0):
-        assert pool.should_scale_down() is False  # timestamps too recent
+        assert fill_and_check_scale_down(pool) is False  # timestamps too recent
 
     # After scaledown_wait
     with patch('time.monotonic', return_value=base + 100.0):
-        assert pool.should_scale_down() is True
+        assert fill_and_check_scale_down(pool) is True
 
 
 @pytest.mark.asyncio
@@ -172,7 +174,7 @@ async def test_status_data_includes_usage_diagnostics(fake_pool_factory):
     base = 1000.0
     # Fill: running_ct=2, so keys 1-2 blocked, keys 3-4 idle
     with patch('time.monotonic', return_value=base):
-        pool.should_scale_down()
+        fill_and_check_scale_down(pool)
 
     with patch('time.monotonic', return_value=base + 10.0):
         data = pool.get_status_data()
@@ -233,13 +235,35 @@ async def test_scaledown_reserve_keeps_surplus(fake_pool_factory):
     base = 1000.0
     # First tick: keys 1-2 blocked, keys 3-6 idle timestamps
     with patch('time.monotonic', return_value=base):
-        assert pool.should_scale_down() is False
+        assert fill_and_check_scale_down(pool) is False
 
     # After scaledown_wait: surplus above reserve aged out
     with patch('time.monotonic', return_value=base + 100.0):
-        assert pool.should_scale_down() is True
+        assert fill_and_check_scale_down(pool) is True
         await pool.scale_workers()
 
     statuses = [w.status for w in pool.workers]
     assert statuses.count('stopping') == 2  # scaled from 6 to 4
     assert statuses.count('ready') == 4  # 2 busy + 2 reserve
+
+
+@pytest.mark.asyncio
+async def test_scaledown_limit_per_tick(fake_pool_factory):
+    """Scale-down is capped at 300 per tick to guard against runaway loops.
+    With 350 idle workers and a limit of 300, only 300 should be stopped in one tick."""
+    pool = fake_pool_factory(min_workers=1, max_workers=400)
+
+    for _ in range(350):
+        await pool.up()
+
+    base = 1000.0
+    with patch('time.monotonic', return_value=base):
+        fill_and_check_scale_down(pool)
+
+    with patch('time.monotonic', return_value=base + 100.0):
+        await pool.scale_workers()
+
+    stopping = [w for w in pool.workers if w.status == 'stopping']
+    capacity = [w for w in pool.workers if w.counts_for_capacity]
+    assert len(stopping) == 300
+    assert len(capacity) == 50

--- a/asyncio_tests/unit/service/test_pool_scaledown.py
+++ b/asyncio_tests/unit/service/test_pool_scaledown.py
@@ -129,6 +129,7 @@ async def test_status_data_includes_last_used_diagnostics(pool_factory):
     }
 
     data = pool.get_status_data()
+    assert data["worker_ct"] == 0  # no workers created, just testing status data formatting
     assert data["last_used_by_ct_count"] == 6
 
     top5 = data["last_used_by_ct_top5"]

--- a/asyncio_tests/unit/service/test_pool_scaledown.py
+++ b/asyncio_tests/unit/service/test_pool_scaledown.py
@@ -1,14 +1,15 @@
 # Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+# See also: tests/unit/service/test_usage_tracker.py for synchronous unit tests of WorkerUsageTracker
 import time
 
 import pytest
 
-from dispatcherd.service.pool import _SCALE_DOWN_BLOCKED
+from dispatcherd.service.pool import WorkerUsageTracker
 
 
 @pytest.mark.asyncio
 async def test_scale_down_when_never_needed_this_many_workers(pool_factory):
-    """Core regression: if last_used_by_ct has entries for counts 1-2 but NOT 3,
+    """Core regression: if _last_used_by_ct has entries for counts 1-2 but NOT 3,
     should_scale_down() must return True and scale_workers() must produce a stopping worker."""
     pool = pool_factory(min_workers=1, max_workers=10)
 
@@ -18,7 +19,7 @@ async def test_scale_down_when_never_needed_this_many_workers(pool_factory):
         pool.workers.get_by_id(worker_id).status = 'ready'
 
     # Only have entries for counts 1 and 2, NOT 3
-    pool.last_used_by_ct = {
+    pool.usage_tracker._last_used_by_ct = {
         1: time.monotonic() - 120.0,
         2: time.monotonic() - 120.0,
     }
@@ -31,7 +32,7 @@ async def test_scale_down_when_never_needed_this_many_workers(pool_factory):
 
 @pytest.mark.asyncio
 async def test_scale_down_blocked_by_sentinel(pool_factory):
-    """3 ready idle workers with last_used_by_ct[3] set to the sentinel.
+    """3 ready idle workers with _last_used_by_ct[3] set to the sentinel.
     should_scale_down() must return False."""
     pool = pool_factory(min_workers=1, max_workers=10)
 
@@ -39,14 +40,14 @@ async def test_scale_down_blocked_by_sentinel(pool_factory):
         worker_id = await pool.up()
         pool.workers.get_by_id(worker_id).status = 'ready'
 
-    pool.last_used_by_ct[3] = _SCALE_DOWN_BLOCKED
+    pool.usage_tracker.record_task_start(3)
 
     assert pool.should_scale_down() is False
 
 
 @pytest.mark.asyncio
 async def test_scale_down_cascade_through_gaps(pool_factory):
-    """10 ready idle workers, last_used_by_ct only has entries for counts 1-5.
+    """10 ready idle workers, _last_used_by_ct only has entries for counts 1-5.
     Repeatedly calling scale_workers() should scale all the way down to min_workers=1."""
     pool = pool_factory(min_workers=1, max_workers=10)
 
@@ -55,7 +56,7 @@ async def test_scale_down_cascade_through_gaps(pool_factory):
         pool.workers.get_by_id(worker_id).status = 'ready'
 
     # Only populate entries for counts 1-5
-    pool.last_used_by_ct = {i: time.monotonic() - 120.0 for i in range(1, 6)}
+    pool.usage_tracker._last_used_by_ct = {i: time.monotonic() - 120.0 for i in range(1, 6)}
 
     # Repeatedly scale down, retiring stopped workers between calls
     for _ in range(20):  # enough iterations to converge
@@ -72,7 +73,7 @@ async def test_scale_down_cascade_through_gaps(pool_factory):
 
 @pytest.mark.asyncio
 async def test_scale_down_with_conflicting_stale_data(pool_factory):
-    """5 ready idle workers exercising all three states of last_used_by_ct[5]:
+    """5 ready idle workers exercising all three states of _last_used_by_ct[5]:
     sentinel (False), old timestamp (True), recent timestamp (False), absent key (True)."""
     pool = pool_factory(min_workers=1, max_workers=10)
 
@@ -81,25 +82,25 @@ async def test_scale_down_with_conflicting_stale_data(pool_factory):
         pool.workers.get_by_id(worker_id).status = 'ready'
 
     # State 1: sentinel blocks scale-down
-    pool.last_used_by_ct[5] = _SCALE_DOWN_BLOCKED
+    pool.usage_tracker.record_task_start(5)
     assert pool.should_scale_down() is False
 
     # State 2: old timestamp allows scale-down
-    pool.last_used_by_ct[5] = time.monotonic() - 120.0
+    pool.usage_tracker._last_used_by_ct[5] = time.monotonic() - 120.0
     assert pool.should_scale_down() is True
 
     # State 3: recent timestamp blocks scale-down
-    pool.last_used_by_ct[5] = time.monotonic()
+    pool.usage_tracker._last_used_by_ct[5] = time.monotonic()
     assert pool.should_scale_down() is False
 
     # State 4: absent key allows scale-down
-    del pool.last_used_by_ct[5]
+    del pool.usage_tracker._last_used_by_ct[5]
     assert pool.should_scale_down() is True
 
 
 @pytest.mark.asyncio
 async def test_status_data_includes_last_used_diagnostics(pool_factory):
-    """Populate last_used_by_ct with 6 entries mixing sentinels and timestamps.
+    """Populate _last_used_by_ct with 6 entries mixing sentinels and timestamps.
     Assert get_status_data() includes count, top5, and near-worker-ct with correct formatting."""
     pool = pool_factory(min_workers=1, max_workers=10)
 
@@ -109,20 +110,20 @@ async def test_status_data_includes_last_used_diagnostics(pool_factory):
         pool.workers.get_by_id(worker_id).status = 'ready'
 
     now = time.monotonic()
-    pool.last_used_by_ct = {
+    pool.usage_tracker._last_used_by_ct = {
         1: now - 100.0,
         2: now - 50.0,
-        3: _SCALE_DOWN_BLOCKED,
+        3: WorkerUsageTracker._SCALE_DOWN_BLOCKED,
         4: now - 10.0,
-        5: _SCALE_DOWN_BLOCKED,
+        5: WorkerUsageTracker._SCALE_DOWN_BLOCKED,
         6: now - 1.0,
     }
 
     data = pool.get_status_data()
     assert data["worker_ct"] == 4
-    assert data["last_used_by_ct_count"] == 6
+    assert data["usage"]["count"] == 6
 
-    top5 = data["last_used_by_ct_top5"]
+    top5 = data["usage"]["top5"]
     # Top 5 highest keys: 6, 5, 4, 3, 2
     assert set(top5.keys()) == {2, 3, 4, 5, 6}
 
@@ -136,7 +137,7 @@ async def test_status_data_includes_last_used_diagnostics(pool_factory):
     assert isinstance(top5[6], float)
 
     # Near-worker-ct shows keys [2..6] centered on worker_ct=4
-    near = data["last_used_near_worker_ct"]
+    near = data["usage"]["near_worker_ct"]
     assert set(near.keys()) == {2, 3, 4, 5, 6}
     assert isinstance(near[2], float)
     assert near[3] == "blocked"
@@ -147,7 +148,7 @@ async def test_status_data_includes_last_used_diagnostics(pool_factory):
 
 @pytest.mark.asyncio
 async def test_status_data_near_worker_ct_shows_absent_keys(pool_factory):
-    """When last_used_by_ct has no entries near the current worker count,
+    """When _last_used_by_ct has no entries near the current worker count,
     the near-worker-ct summary should show 'absent' for missing keys."""
     pool = pool_factory(min_workers=1, max_workers=10)
 
@@ -158,11 +159,11 @@ async def test_status_data_near_worker_ct_shows_absent_keys(pool_factory):
 
     # Only populate entries far from worker_ct=8
     now = time.monotonic()
-    pool.last_used_by_ct = {1: now - 100.0, 2: now - 50.0}
+    pool.usage_tracker._last_used_by_ct = {1: now - 100.0, 2: now - 50.0}
 
     data = pool.get_status_data()
-    near = data["last_used_near_worker_ct"]
-    # Keys [6..10] centered on worker_ct=8, none present in last_used_by_ct
+    near = data["usage"]["near_worker_ct"]
+    # Keys [6..10] centered on worker_ct=8, none present in _last_used_by_ct
     assert set(near.keys()) == {6, 7, 8, 9, 10}
     for k in near:
         assert near[k] == "absent"

--- a/asyncio_tests/unit/service/test_pool_scaledown.py
+++ b/asyncio_tests/unit/service/test_pool_scaledown.py
@@ -7,32 +7,39 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_scale_down_when_never_needed_this_many_workers(pool_factory):
+async def test_scale_down_when_never_needed_this_many_workers(fake_pool_factory):
     """Core regression: if usage tracker has entries for counts 1-2 but NOT 3,
-    should_scale_down() must return True and scale_workers() must produce a stopping worker."""
-    pool = pool_factory(min_workers=1, max_workers=10)
+    should_scale_down() must fill the gap and allow scale-down after scaledown_wait."""
+    pool = fake_pool_factory(min_workers=1, max_workers=10)
 
     # Create 3 ready idle workers
     for _ in range(3):
         worker_id = await pool.up()
         pool.workers.get_by_id(worker_id).status = 'ready'
 
+    base = 1000.0
     # Only have entries for counts 1 and 2, NOT 3
-    with patch('time.monotonic', return_value=time.monotonic() - 120.0):
+    with patch('time.monotonic', return_value=base):
         pool.usage_tracker.record_task_finish(1)
         pool.usage_tracker.record_task_finish(2)
 
-    assert pool.should_scale_down() is True
-    await pool.scale_workers()
+    # First call detects the gap at count 3, fills it as idle — too recent to scale down
+    with patch('time.monotonic', return_value=base + 100.0):
+        assert pool.should_scale_down() is False
+
+    # After scaledown_wait, the filled entry is old enough — scale down proceeds
+    with patch('time.monotonic', return_value=base + 200.0):
+        assert pool.should_scale_down() is True
+        await pool.scale_workers()
     statuses = [w.status for w in pool.workers]
     assert 'stopping' in statuses
 
 
 @pytest.mark.asyncio
-async def test_scale_down_blocked_by_sentinel(pool_factory):
+async def test_scale_down_blocked_by_sentinel(fake_pool_factory):
     """3 ready idle workers with usage tracker recording active work at count 3.
     should_scale_down() must return False."""
-    pool = pool_factory(min_workers=1, max_workers=10)
+    pool = fake_pool_factory(min_workers=1, max_workers=10)
 
     for _ in range(3):
         worker_id = await pool.up()
@@ -44,38 +51,46 @@ async def test_scale_down_blocked_by_sentinel(pool_factory):
 
 
 @pytest.mark.asyncio
-async def test_scale_down_cascade_through_gaps(pool_factory):
+async def test_scale_down_cascade_through_gaps(fake_pool_factory):
     """10 ready idle workers, usage tracker only has entries for counts 1-5.
-    Repeatedly calling scale_workers() should scale all the way down to min_workers=1."""
-    pool = pool_factory(min_workers=1, max_workers=10)
+    After filling gaps and waiting scaledown_wait, repeatedly calling
+    scale_workers() should scale all the way down to min_workers=1."""
+    pool = fake_pool_factory(min_workers=1, max_workers=10)
 
     for _ in range(10):
         worker_id = await pool.up()
         pool.workers.get_by_id(worker_id).status = 'ready'
 
+    base = 1000.0
     # Only populate entries for counts 1-5
-    with patch('time.monotonic', return_value=time.monotonic() - 120.0):
+    with patch('time.monotonic', return_value=base):
         for i in range(1, 6):
             pool.usage_tracker.record_task_finish(i)
 
-    # Repeatedly scale down, retiring stopped workers between calls
-    for _ in range(20):  # enough iterations to converge
-        await pool.scale_workers()
-        # Mark stopping workers as retired so they no longer count for capacity
-        for w in pool.workers:
-            if w.status == 'stopping':
-                w.status = 'retired'
-                w.retired_at = time.monotonic()
+    # Trigger fill for absent keys 6-10
+    with patch('time.monotonic', return_value=base + 100.0):
+        pool.should_scale_down()
+
+    # After scaledown_wait, both original entries (base) and filled entries
+    # (base+100) are old enough — cascade scales all the way down
+    with patch('time.monotonic', return_value=base + 200.0):
+        for _ in range(20):  # enough iterations to converge
+            await pool.scale_workers()
+            # Mark stopping workers as retired so they no longer count for capacity
+            for w in pool.workers:
+                if w.status == 'stopping':
+                    w.status = 'retired'
+                    w.retired_at = time.monotonic()
 
     capacity_workers = [w for w in pool.workers if w.counts_for_capacity]
     assert len(capacity_workers) == 1
 
 
 @pytest.mark.asyncio
-async def test_scale_down_with_conflicting_stale_data(pool_factory):
+async def test_scale_down_with_conflicting_stale_data(fake_pool_factory):
     """5 ready idle workers exercising all three states of usage tracking:
     sentinel (False), old timestamp (True), recent timestamp (False), absent key (True)."""
-    pool = pool_factory(min_workers=1, max_workers=10)
+    pool = fake_pool_factory(min_workers=1, max_workers=10)
 
     for _ in range(5):
         worker_id = await pool.up()
@@ -94,18 +109,22 @@ async def test_scale_down_with_conflicting_stale_data(pool_factory):
     pool.usage_tracker.record_task_finish(5)
     assert pool.should_scale_down() is False
 
-    # State 4: absent key allows scale-down (add a worker to exceed tracked counts)
+    # State 4: absent key — fill first, then scale-down after scaledown_wait
     worker_id = await pool.up()
     pool.workers.get_by_id(worker_id).status = 'ready'
     # Now worker_ct=6, no entry for 6 exists
-    assert pool.should_scale_down() is True
+    base = 1000.0
+    with patch('time.monotonic', return_value=base):
+        assert pool.should_scale_down() is False  # triggers fill, too recent
+    with patch('time.monotonic', return_value=base + 120.0):
+        assert pool.should_scale_down() is True  # past scaledown_wait
 
 
 @pytest.mark.asyncio
-async def test_status_data_includes_last_used_diagnostics(pool_factory):
+async def test_status_data_includes_last_used_diagnostics(fake_pool_factory):
     """Populate usage tracker with 6 entries mixing sentinels and timestamps.
     Assert get_status_data() includes count, top5, and near-worker-ct with correct formatting."""
-    pool = pool_factory(min_workers=1, max_workers=10)
+    pool = fake_pool_factory(min_workers=1, max_workers=10)
 
     # Create 4 ready workers so worker_ct=4
     for _ in range(4):
@@ -154,10 +173,10 @@ async def test_status_data_includes_last_used_diagnostics(pool_factory):
 
 
 @pytest.mark.asyncio
-async def test_status_data_near_worker_ct_shows_absent_keys(pool_factory):
+async def test_status_data_near_worker_ct_shows_absent_keys(fake_pool_factory):
     """When usage tracker has no entries near the current worker count,
     the near-worker-ct summary should show 'absent' for missing keys."""
-    pool = pool_factory(min_workers=1, max_workers=10)
+    pool = fake_pool_factory(min_workers=1, max_workers=10)
 
     # Create 8 ready workers so worker_ct=8
     for _ in range(8):

--- a/asyncio_tests/unit/service/test_pool_scaledown.py
+++ b/asyncio_tests/unit/service/test_pool_scaledown.py
@@ -44,6 +44,28 @@ async def test_scale_down_blocked_by_active_work(fake_pool_factory):
 
 
 @pytest.mark.asyncio
+async def test_task_finish_enables_timely_scale_down(fake_pool_factory):
+    """record_task_finish records a timestamp on the hot path, so scale-down
+    can proceed at the earliest possible moment without waiting for the next
+    periodic fill tick."""
+    pool = fake_pool_factory(min_workers=1, max_workers=10)
+
+    for _ in range(3):
+        worker_id = await pool.up()
+        assert pool.workers.get_by_id(worker_id).status == 'ready'
+
+    base = 1000.0
+    # Simulate a task finishing — sets timestamp at running_ct
+    with patch('time.monotonic', return_value=base):
+        pool.usage_tracker.record_task_finish(3)
+
+    # Periodic fill hasn't run yet, but key 3 already has a timestamp
+    # After scaledown_wait, scale-down proceeds without needing a prior fill tick
+    with patch('time.monotonic', return_value=base + 100.0):
+        assert pool.should_scale_down() is True
+
+
+@pytest.mark.asyncio
 async def test_scale_down_cascade_to_min_workers(fake_pool_factory):
     """10 idle workers.  After two ticks, repeatedly calling scale_workers()
     should scale all the way down to min_workers=1."""

--- a/asyncio_tests/unit/service/test_pool_scaledown.py
+++ b/asyncio_tests/unit/service/test_pool_scaledown.py
@@ -7,28 +7,22 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_scale_down_when_never_needed_this_many_workers(fake_pool_factory):
-    """Core regression: if usage tracker has entries for counts 1-2 but NOT 3,
-    should_scale_down() must fill the gap and allow scale-down after scaledown_wait."""
+async def test_scale_down_idle_workers(fake_pool_factory):
+    """3 idle workers, no running tasks.  First tick fills the tracker,
+    second tick (after scaledown_wait) allows scale-down."""
     pool = fake_pool_factory(min_workers=1, max_workers=10)
 
-    # Create 3 ready idle workers
     for _ in range(3):
         worker_id = await pool.up()
         assert pool.workers.get_by_id(worker_id).status == 'ready'
 
     base = 1000.0
-    # Only have entries for counts 1 and 2, NOT 3
+    # First tick: fills keys 1-3 as idle timestamps — too recent to scale down
     with patch('time.monotonic', return_value=base):
-        pool.usage_tracker.record_task_finish(1)
-        pool.usage_tracker.record_task_finish(2)
-
-    # First call detects the gap at count 3, fills it as idle — too recent to scale down
-    with patch('time.monotonic', return_value=base + 100.0):
         assert pool.should_scale_down() is False
 
-    # After scaledown_wait, the filled entry is old enough — scale down proceeds
-    with patch('time.monotonic', return_value=base + 200.0):
+    # Second tick after scaledown_wait: timestamps are old enough
+    with patch('time.monotonic', return_value=base + 100.0):
         assert pool.should_scale_down() is True
         await pool.scale_workers()
     statuses = [w.status for w in pool.workers]
@@ -36,25 +30,23 @@ async def test_scale_down_when_never_needed_this_many_workers(fake_pool_factory)
 
 
 @pytest.mark.asyncio
-async def test_scale_down_blocked_by_sentinel(fake_pool_factory):
-    """3 ready idle workers with usage tracker recording active work at count 3.
-    should_scale_down() must return False."""
+async def test_scale_down_blocked_by_active_work(fake_pool_factory):
+    """3 workers with 3 running tasks — should_scale_down() must return False."""
     pool = fake_pool_factory(min_workers=1, max_workers=10)
 
     for _ in range(3):
         worker_id = await pool.up()
-        assert pool.workers.get_by_id(worker_id).status == 'ready'
-
-    pool.usage_tracker.record_task_start(3)
+        worker = pool.workers.get_by_id(worker_id)
+        assert worker.status == 'ready'
+        await worker.start_task({'task': 'busy'})
 
     assert pool.should_scale_down() is False
 
 
 @pytest.mark.asyncio
-async def test_scale_down_cascade_through_gaps(fake_pool_factory):
-    """10 ready idle workers, usage tracker only has entries for counts 1-5.
-    After filling gaps and waiting scaledown_wait, repeatedly calling
-    scale_workers() should scale all the way down to min_workers=1."""
+async def test_scale_down_cascade_to_min_workers(fake_pool_factory):
+    """10 idle workers.  After two ticks, repeatedly calling scale_workers()
+    should scale all the way down to min_workers=1."""
     pool = fake_pool_factory(min_workers=1, max_workers=10)
 
     for _ in range(10):
@@ -62,21 +54,14 @@ async def test_scale_down_cascade_through_gaps(fake_pool_factory):
         assert pool.workers.get_by_id(worker_id).status == 'ready'
 
     base = 1000.0
-    # Only populate entries for counts 1-5
+    # First tick: fill all keys as idle
     with patch('time.monotonic', return_value=base):
-        for i in range(1, 6):
-            pool.usage_tracker.record_task_finish(i)
-
-    # Trigger fill for absent keys 6-10
-    with patch('time.monotonic', return_value=base + 100.0):
         pool.should_scale_down()
 
-    # After scaledown_wait, both original entries (base) and filled entries
-    # (base+100) are old enough — cascade scales all the way down
-    with patch('time.monotonic', return_value=base + 200.0):
+    # After scaledown_wait, cascade scales all the way down
+    with patch('time.monotonic', return_value=base + 100.0):
         for _ in range(20):  # enough iterations to converge
             await pool.scale_workers()
-            # Mark stopping workers as retired so they no longer count for capacity
             for w in pool.workers:
                 if w.status == 'stopping':
                     w.status = 'retired'
@@ -87,89 +72,104 @@ async def test_scale_down_cascade_through_gaps(fake_pool_factory):
 
 
 @pytest.mark.asyncio
-async def test_scale_down_with_conflicting_stale_data(fake_pool_factory):
-    """5 ready idle workers exercising all three states of usage tracking:
-    sentinel (False), old timestamp (True), recent timestamp (False), absent key (True)."""
+async def test_scale_down_respects_active_load(fake_pool_factory):
+    """5 workers, 3 running tasks.  Should scale down surplus but never
+    below the active load."""
     pool = fake_pool_factory(min_workers=1, max_workers=10)
 
+    workers = []
     for _ in range(5):
         worker_id = await pool.up()
-        assert pool.workers.get_by_id(worker_id).status == 'ready'
+        workers.append(pool.workers.get_by_id(worker_id))
+        assert workers[-1].status == 'ready'
 
-    # State 1: sentinel blocks scale-down
-    pool.usage_tracker.record_task_start(5)
-    assert pool.should_scale_down() is False
+    # Give 3 workers tasks
+    for i in range(3):
+        await workers[i].start_task({'task': f'busy-{i}'})
 
-    # State 2: old timestamp allows scale-down
-    with patch('time.monotonic', return_value=time.monotonic() - 120.0):
-        pool.usage_tracker.record_task_finish(5)
-    assert pool.should_scale_down() is True
-
-    # State 3: recent timestamp blocks scale-down
-    pool.usage_tracker.record_task_finish(5)
-    assert pool.should_scale_down() is False
-
-    # State 4: absent key — fill first, then scale-down after scaledown_wait
-    worker_id = await pool.up()
-    pool.workers.get_by_id(worker_id).status = 'ready'
-    # Now worker_ct=6, no entry for 6 exists
     base = 1000.0
+    # First tick: keys 1-3 blocked, keys 4-5 idle timestamps
     with patch('time.monotonic', return_value=base):
-        assert pool.should_scale_down() is False  # triggers fill, too recent
-    with patch('time.monotonic', return_value=base + 120.0):
-        assert pool.should_scale_down() is True  # past scaledown_wait
+        assert pool.should_scale_down() is False
+
+    # After scaledown_wait: surplus keys aged out, scale down from 5
+    with patch('time.monotonic', return_value=base + 100.0):
+        assert pool.should_scale_down() is True
+        await pool.scale_workers()
+
+    statuses = [w.status for w in pool.workers]
+    assert statuses.count('stopping') == 1
+    assert statuses.count('ready') == 4
 
 
 @pytest.mark.asyncio
-async def test_status_data_includes_last_used_diagnostics(fake_pool_factory):
-    """Populate usage tracker with 6 entries mixing sentinels and timestamps.
-    Assert get_status_data() includes count, top5, and near-worker-ct with correct formatting."""
+async def test_blocked_entries_clear_when_load_drops(fake_pool_factory):
+    """When demand drops, previously blocked entries should convert to
+    timestamps and eventually allow scale-down."""
     pool = fake_pool_factory(min_workers=1, max_workers=10)
 
-    # Create 4 ready workers so worker_ct=4
-    for _ in range(4):
+    workers = []
+    for _ in range(5):
         worker_id = await pool.up()
-        assert pool.workers.get_by_id(worker_id).status == 'ready'
+        workers.append(pool.workers.get_by_id(worker_id))
+        assert workers[-1].status == 'ready'
+
+    # All 5 busy
+    for w in workers:
+        await w.start_task({'task': 'busy'})
 
     base = 1000.0
     with patch('time.monotonic', return_value=base):
-        pool.usage_tracker.record_task_finish(1)
-    with patch('time.monotonic', return_value=base + 50.0):
-        pool.usage_tracker.record_task_finish(2)
-    pool.usage_tracker.record_task_start(3)
-    with patch('time.monotonic', return_value=base + 90.0):
-        pool.usage_tracker.record_task_finish(4)
-    pool.usage_tracker.record_task_start(5)
-    with patch('time.monotonic', return_value=base + 99.0):
-        pool.usage_tracker.record_task_finish(6)
+        assert pool.should_scale_down() is False  # all blocked
 
+    # Tasks finish — clear current_task to simulate completion
+    for w in workers:
+        w.current_task = None
+
+    # Next tick: running_ct=0, previously blocked keys become timestamps
+    with patch('time.monotonic', return_value=base + 1.0):
+        assert pool.should_scale_down() is False  # timestamps too recent
+
+    # After scaledown_wait
     with patch('time.monotonic', return_value=base + 100.0):
+        assert pool.should_scale_down() is True
+
+
+@pytest.mark.asyncio
+async def test_status_data_includes_usage_diagnostics(fake_pool_factory):
+    """Populate tracker via fill_unknown_usage with a mix of blocked and idle entries.
+    Assert get_status_data() includes count, top5, and near-worker-ct."""
+    pool = fake_pool_factory(min_workers=1, max_workers=10)
+
+    # Create 4 ready workers, give 2 of them tasks
+    workers = []
+    for _ in range(4):
+        worker_id = await pool.up()
+        workers.append(pool.workers.get_by_id(worker_id))
+        assert workers[-1].status == 'ready'
+
+    await workers[0].start_task({'task': 'busy-1'})
+    await workers[1].start_task({'task': 'busy-2'})
+
+    base = 1000.0
+    # Fill: running_ct=2, so keys 1-2 blocked, keys 3-4 idle
+    with patch('time.monotonic', return_value=base):
+        pool.should_scale_down()
+
+    with patch('time.monotonic', return_value=base + 10.0):
         data = pool.get_status_data()
 
     assert data["worker_ct"] == 4
-    assert data["usage"]["count"] == 6
+    assert data["usage"]["count"] == 4
 
-    top5 = data["usage"]["top5"]
-    # Top 5 highest keys: 6, 5, 4, 3, 2
-    assert set(top5.keys()) == {2, 3, 4, 5, 6}
-
-    # Sentinel entries show "blocked"
-    assert top5[3] == "blocked"
-    assert top5[5] == "blocked"
-
-    # Timestamp entries show seconds-ago as floats
-    assert isinstance(top5[2], float)
-    assert isinstance(top5[4], float)
-    assert isinstance(top5[6], float)
-
-    # Near-worker-ct shows keys [2..6] centered on worker_ct=4
+    # Near worker_ct=4: keys [2..6]
     near = data["usage"]["near_worker_ct"]
     assert set(near.keys()) == {2, 3, 4, 5, 6}
-    assert isinstance(near[2], float)
-    assert near[3] == "blocked"
+    assert near[2] == "blocked"
+    assert isinstance(near[3], float)
     assert isinstance(near[4], float)
-    assert near[5] == "blocked"
-    assert isinstance(near[6], float)
+    assert near[5] == "absent"
+    assert near[6] == "absent"
 
 
 @pytest.mark.asyncio
@@ -183,9 +183,8 @@ async def test_status_data_near_worker_ct_shows_absent_keys(fake_pool_factory):
         worker_id = await pool.up()
         assert pool.workers.get_by_id(worker_id).status == 'ready'
 
-    # Only populate entries far from worker_ct=8
-    pool.usage_tracker.record_task_finish(1)
-    pool.usage_tracker.record_task_finish(2)
+    # Fill only keys 1-2 (via fill with worker_ct=2)
+    pool.usage_tracker.fill_unknown_usage(worker_ct=2, running_ct=0)
 
     data = pool.get_status_data()
     near = data["usage"]["near_worker_ct"]

--- a/asyncio_tests/unit/service/test_pool_scaledown.py
+++ b/asyncio_tests/unit/service/test_pool_scaledown.py
@@ -100,8 +100,13 @@ async def test_scale_down_with_conflicting_stale_data(pool_factory):
 @pytest.mark.asyncio
 async def test_status_data_includes_last_used_diagnostics(pool_factory):
     """Populate last_used_by_ct with 6 entries mixing sentinels and timestamps.
-    Assert get_status_data() includes count and top5 with correct formatting."""
+    Assert get_status_data() includes count, top5, and near-worker-ct with correct formatting."""
     pool = pool_factory(min_workers=1, max_workers=10)
+
+    # Create 4 ready workers so worker_ct=4
+    for _ in range(4):
+        worker_id = await pool.up()
+        pool.workers.get_by_id(worker_id).status = 'ready'
 
     now = time.monotonic()
     pool.last_used_by_ct = {
@@ -114,7 +119,7 @@ async def test_status_data_includes_last_used_diagnostics(pool_factory):
     }
 
     data = pool.get_status_data()
-    assert data["worker_ct"] == 0  # no workers created, just testing status data formatting
+    assert data["worker_ct"] == 4
     assert data["last_used_by_ct_count"] == 6
 
     top5 = data["last_used_by_ct_top5"]
@@ -129,3 +134,35 @@ async def test_status_data_includes_last_used_diagnostics(pool_factory):
     assert isinstance(top5[2], float)
     assert isinstance(top5[4], float)
     assert isinstance(top5[6], float)
+
+    # Near-worker-ct shows keys [2..6] centered on worker_ct=4
+    near = data["last_used_near_worker_ct"]
+    assert set(near.keys()) == {2, 3, 4, 5, 6}
+    assert isinstance(near[2], float)
+    assert near[3] == "blocked"
+    assert isinstance(near[4], float)
+    assert near[5] == "blocked"
+    assert isinstance(near[6], float)
+
+
+@pytest.mark.asyncio
+async def test_status_data_near_worker_ct_shows_absent_keys(pool_factory):
+    """When last_used_by_ct has no entries near the current worker count,
+    the near-worker-ct summary should show 'absent' for missing keys."""
+    pool = pool_factory(min_workers=1, max_workers=10)
+
+    # Create 8 ready workers so worker_ct=8
+    for _ in range(8):
+        worker_id = await pool.up()
+        pool.workers.get_by_id(worker_id).status = 'ready'
+
+    # Only populate entries far from worker_ct=8
+    now = time.monotonic()
+    pool.last_used_by_ct = {1: now - 100.0, 2: now - 50.0}
+
+    data = pool.get_status_data()
+    near = data["last_used_near_worker_ct"]
+    # Keys [6..10] centered on worker_ct=8, none present in last_used_by_ct
+    assert set(near.keys()) == {6, 7, 8, 9, 10}
+    for k in near:
+        assert near[k] == "absent"

--- a/asyncio_tests/unit/service/test_pool_scaledown.py
+++ b/asyncio_tests/unit/service/test_pool_scaledown.py
@@ -15,7 +15,7 @@ async def test_scale_down_when_never_needed_this_many_workers(fake_pool_factory)
     # Create 3 ready idle workers
     for _ in range(3):
         worker_id = await pool.up()
-        pool.workers.get_by_id(worker_id).status = 'ready'
+        assert pool.workers.get_by_id(worker_id).status == 'ready'
 
     base = 1000.0
     # Only have entries for counts 1 and 2, NOT 3
@@ -43,7 +43,7 @@ async def test_scale_down_blocked_by_sentinel(fake_pool_factory):
 
     for _ in range(3):
         worker_id = await pool.up()
-        pool.workers.get_by_id(worker_id).status = 'ready'
+        assert pool.workers.get_by_id(worker_id).status == 'ready'
 
     pool.usage_tracker.record_task_start(3)
 
@@ -59,7 +59,7 @@ async def test_scale_down_cascade_through_gaps(fake_pool_factory):
 
     for _ in range(10):
         worker_id = await pool.up()
-        pool.workers.get_by_id(worker_id).status = 'ready'
+        assert pool.workers.get_by_id(worker_id).status == 'ready'
 
     base = 1000.0
     # Only populate entries for counts 1-5
@@ -94,7 +94,7 @@ async def test_scale_down_with_conflicting_stale_data(fake_pool_factory):
 
     for _ in range(5):
         worker_id = await pool.up()
-        pool.workers.get_by_id(worker_id).status = 'ready'
+        assert pool.workers.get_by_id(worker_id).status == 'ready'
 
     # State 1: sentinel blocks scale-down
     pool.usage_tracker.record_task_start(5)
@@ -129,7 +129,7 @@ async def test_status_data_includes_last_used_diagnostics(fake_pool_factory):
     # Create 4 ready workers so worker_ct=4
     for _ in range(4):
         worker_id = await pool.up()
-        pool.workers.get_by_id(worker_id).status = 'ready'
+        assert pool.workers.get_by_id(worker_id).status == 'ready'
 
     base = 1000.0
     with patch('time.monotonic', return_value=base):
@@ -181,7 +181,7 @@ async def test_status_data_near_worker_ct_shows_absent_keys(fake_pool_factory):
     # Create 8 ready workers so worker_ct=8
     for _ in range(8):
         worker_id = await pool.up()
-        pool.workers.get_by_id(worker_id).status = 'ready'
+        assert pool.workers.get_by_id(worker_id).status == 'ready'
 
     # Only populate entries far from worker_ct=8
     pool.usage_tracker.record_task_finish(1)

--- a/asyncio_tests/unit/service/test_pool_scaledown.py
+++ b/asyncio_tests/unit/service/test_pool_scaledown.py
@@ -1,24 +1,9 @@
 # Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 import time
-from typing import Callable
 
 import pytest
 
-from dispatcherd.service.asyncio_tasks import SharedAsyncObjects
-from dispatcherd.service.pool import _SCALE_DOWN_BLOCKED, WorkerPool
-from dispatcherd.service.process import ProcessManager
-
-
-@pytest.fixture
-def pool_factory(test_settings) -> Callable[..., WorkerPool]:
-    def _factory(**kwargs_overrides) -> WorkerPool:
-        pm = ProcessManager(settings=test_settings)
-        kwargs = dict(process_manager=pm, min_workers=5, max_workers=5, shared=SharedAsyncObjects())
-        kwargs.update(kwargs_overrides)
-        pool = WorkerPool(**kwargs)
-        return pool
-
-    return _factory
+from dispatcherd.service.pool import _SCALE_DOWN_BLOCKED
 
 
 @pytest.mark.asyncio

--- a/asyncio_tests/unit/service/test_pool_scaledown.py
+++ b/asyncio_tests/unit/service/test_pool_scaledown.py
@@ -210,3 +210,35 @@ async def test_status_data_near_worker_ct_shows_absent_keys(fake_pool_factory):
     assert set(near.keys()) == {6, 7, 8, 9, 10}
     for k in near:
         assert near[k] == "absent"
+
+
+@pytest.mark.asyncio
+async def test_scaledown_reserve_keeps_surplus(fake_pool_factory):
+    """6 workers, 2 busy, scaledown_reserve=2, min_workers=1.
+    After scaledown_wait, scale_workers should stop 2 workers
+    (down to 4 = 2 demand + 2 reserve), not all the way to 1."""
+    pool = fake_pool_factory(min_workers=1, max_workers=10, scaledown_reserve=2)
+
+    workers = []
+    for _ in range(6):
+        worker_id = await pool.up()
+        workers.append(pool.workers.get_by_id(worker_id))
+        assert workers[-1].status == 'ready'
+
+    # Give 2 workers tasks
+    for i in range(2):
+        await workers[i].start_task({'task': f'busy-{i}'})
+
+    base = 1000.0
+    # First tick: keys 1-2 blocked, keys 3-6 idle timestamps
+    with patch('time.monotonic', return_value=base):
+        assert pool.should_scale_down() is False
+
+    # After scaledown_wait: surplus above reserve aged out
+    with patch('time.monotonic', return_value=base + 100.0):
+        assert pool.should_scale_down() is True
+        await pool.scale_workers()
+
+    statuses = [w.status for w in pool.workers]
+    assert statuses.count('stopping') == 2  # scaled from 6 to 4
+    assert statuses.count('ready') == 4  # 2 busy + 2 reserve

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -275,6 +275,8 @@ class WorkerUsageTracker:
         now = time.monotonic()
         result: dict[int, str | float] = {}
         for k in keys:
+            if k < 0:
+                continue
             if k not in self._last_used_by_ct:
                 result[k] = "absent"
             elif self._last_used_by_ct[k] is self._SCALE_DOWN_BLOCKED:

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -250,9 +250,41 @@ class WorkerUsageTracker:
     def record_task_finish(self, running_ct: int) -> None:
         self._last_used_by_ct[running_ct] = time.monotonic()
 
+    def is_tracked(self, worker_ct: int) -> bool:
+        """Check if the tracker has a record for this worker count."""
+        return worker_ct in self._last_used_by_ct
+
+    def fill_unknown_usage(self, worker_ct: int, running_ct: int) -> None:
+        """Lazy fallback for record_task_start / record_task_finish.
+
+        Normally, every task start and finish records usage at the current
+        worker count via record_task_start / record_task_finish.  This keeps
+        the hot path fast (O(1) dict write, no traversals).  However, if a
+        recording is ever missed — e.g. due to a bug or a race — the tracker
+        may have no entry for the current worker count, leaving scale-down
+        unable to make a decision.
+
+        This method is the lazy corrective: called from the periodic
+        scale-down check only when a gap is detected.  It fills all missing
+        entries up to worker_ct based on current demand.  Keys at or below
+        running_ct are set to blocked (actively in use).  Keys above
+        running_ct are set to the current timestamp (idle surplus,
+        scale-down allowed after scaledown_wait).  Existing entries are
+        never overwritten.
+        """
+        now = time.monotonic()
+        for ct in range(1, worker_ct + 1):
+            if ct not in self._last_used_by_ct:
+                if ct <= running_ct:
+                    self._last_used_by_ct[ct] = self._SCALE_DOWN_BLOCKED
+                    logger.warning(f'Backfilled missing usage entry for count {ct} as blocked (running_ct={running_ct})')
+                else:
+                    self._last_used_by_ct[ct] = now
+                    logger.warning(f'Backfilled missing usage entry for count {ct} as idle (running_ct={running_ct})')
+
     def should_scale_down(self, worker_ct: int) -> bool:
         if worker_ct not in self._last_used_by_ct:
-            logger.info(
+            logger.warning(
                 f'No record of needing {worker_ct} workers, allowing scale-down'
                 f' (worker count exceeded tracked usage, near={self._near_worker_ct_summary(worker_ct)})'
             )
@@ -405,6 +437,9 @@ class WorkerPool(WorkerPoolProtocol):
     def should_scale_down(self) -> bool:
         "If True, we have not had enough work lately to justify the number of workers we are running"
         worker_ct = len([worker for worker in self.workers if worker.counts_for_capacity])
+        if not self.usage_tracker.is_tracked(worker_ct):
+            running_ct = self.get_running_count()
+            self.usage_tracker.fill_unknown_usage(worker_ct, running_ct)
         return self.usage_tracker.should_scale_down(worker_ct)
 
     async def scale_workers(self) -> int:

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -230,12 +230,12 @@ class WorkerData(WorkerDataProtocol):
 
 
 class WorkerUsageTracker:
-    """Tracks when the pool last needed N concurrent workers, for scale-down decisions.
+    """Scale-down memory keyed by worker count.
 
-    Three states per worker-count key:
-    - absent:  never needed this many → scale down immediately
-    - _SCALE_DOWN_BLOCKED:  actively in use → block scale-down
-    - float timestamp:  last finished at this count → scale down if idle > scaledown_wait
+    Each key is one of:
+    - absent: never observed as needed
+    - _SCALE_DOWN_BLOCKED: currently at or below demand
+    - float timestamp: last time that level was released
     """
 
     _SCALE_DOWN_BLOCKED = object()
@@ -245,42 +245,25 @@ class WorkerUsageTracker:
         self.scaledown_wait = scaledown_wait
         self.scaledown_reserve = scaledown_reserve
 
-    def record_task_finish(self, running_ct: int) -> None:
-        """Record a timestamp when a task finishes at the given running count.
+    def record_task_finish(self, demand_ct: int) -> None:
+        """Mark a just-released demand level with a timestamp.
 
-        Called from the task-completion hot path.  This is the only per-task
-        hook — there is no corresponding record_task_start because blocking
-        is handled entirely by the periodic fill_unknown_usage.  Recording
-        the finish timestamp allows scale-down to proceed at the earliest
-        possible moment rather than waiting for the next periodic tick.
+        This hot-path write avoids waiting for the next periodic fill cycle.
         """
-        self._last_used_by_ct[running_ct] = time.monotonic()
+        self._last_used_by_ct[demand_ct] = time.monotonic()
 
-    def fill_unknown_usage(self, worker_ct: int, running_ct: int) -> None:
-        """Update the tracker with the current observed state of the pool.
+    def fill_unknown_usage(self, worker_ct: int, demand_ct: int) -> None:
+        """Apply current pool state to the tracker.
 
-        Called on every periodic scale-down check.  This is the primary input
-        mechanism for blocking scale-down — keys at or below the current load
-        are marked as blocked.  record_task_finish provides the complementary
-        timestamp recording on the hot path for timely scale-down.
-
-        For each worker-count key up to worker_ct:
-        - Keys at or below running_ct are set to blocked (actively in use),
-          regardless of previous state.
-        - Keys above running_ct that are absent or previously blocked are
-          set to the current timestamp (idle surplus, scale-down allowed
-          after scaledown_wait).
-        - Keys above running_ct that already have a timestamp are left
-          alone so they continue aging toward scaledown_wait.
-
-        Keys above worker_ct that are stale blocked entries (left over from
-        a previously higher worker count) are downgraded to the current
-        timestamp so they age out naturally instead of showing as blocked
-        in status output forever.
+        Principles:
+        - Counts `<= demand_ct` are blocked.
+        - Idle surplus counts (`demand_ct < ct <= worker_ct`) get timestamps
+          only when first seen or when transitioning from blocked.
+        - Existing idle timestamps keep aging.
         """
         now = time.monotonic()
         for ct in range(1, worker_ct + 1):
-            if ct <= running_ct:
+            if ct <= demand_ct:
                 self._last_used_by_ct[ct] = self._SCALE_DOWN_BLOCKED
             elif ct not in self._last_used_by_ct or self._last_used_by_ct[ct] is self._SCALE_DOWN_BLOCKED:
                 self._last_used_by_ct[ct] = now
@@ -288,7 +271,8 @@ class WorkerUsageTracker:
             if ct > worker_ct and value is self._SCALE_DOWN_BLOCKED:
                 self._last_used_by_ct[ct] = now
 
-    def should_scale_down(self, worker_ct: int, running_ct: int = 0) -> bool:
+    def should_scale_down(self, worker_ct: int, demand_ct: int = 0) -> bool:
+        """Return whether current capacity should retire one worker now."""
         if worker_ct not in self._last_used_by_ct:
             logger.warning(
                 f'No record of needing {worker_ct} workers, allowing scale-down'
@@ -298,7 +282,7 @@ class WorkerUsageTracker:
         last_used = self._last_used_by_ct[worker_ct]
         if last_used is self._SCALE_DOWN_BLOCKED:
             return False
-        if self.scaledown_reserve and worker_ct <= running_ct + self.scaledown_reserve:
+        if self.scaledown_reserve and worker_ct <= demand_ct + self.scaledown_reserve:
             return False
         delta = time.monotonic() - last_used  # type: ignore[operator]
         return bool(delta > self.scaledown_wait)
@@ -784,16 +768,19 @@ class WorkerPool(WorkerPoolProtocol):
                 self.canceled_count += 1
             else:
                 self.finished_count += 1
+            # Capture demand before clearing current_task; this is the level
+            # being released by this completion event.
+            pre_finish_demand_ct = self.active_task_ct()
             if is_stopping:
                 worker.status = 'stopping'
                 if not worker.stopping_at:
                     worker.stopping_at = time.monotonic()
             worker.mark_finished_task()
             self.workers.move_to_end(worker.worker_id)
-            # Record usage after mark_finished_task clears current_task,
-            # so active_task_ct reflects the post-finish state.
+            # Record the just-released demand level. This hot-path timestamp
+            # avoids waiting for the next periodic fill tick to start scale-down aging.
             # Must be under management_lock — see also scale_workers and should_scale_down.
-            self.usage_tracker.record_task_finish(self.active_task_ct())
+            self.usage_tracker.record_task_finish(pre_finish_demand_ct)
 
         if not self.queuer.queued_messages and all(worker.current_task is None for worker in self.workers):
             self.events.work_cleared.set()

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -363,6 +363,7 @@ class WorkerPool(WorkerPoolProtocol):
         worker_ct = len([worker for worker in self.workers if worker.counts_for_capacity])
         if worker_ct not in self.last_used_by_ct:
             # Never needed this many workers, scale down immediately
+            logger.info(f'No record of needing {worker_ct} workers, allowing scale-down (worker count exceeded tracked usage)')
             return True
         last_used = self.last_used_by_ct[worker_ct]
         if last_used is _SCALE_DOWN_BLOCKED:

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -244,43 +244,29 @@ class WorkerUsageTracker:
         self._last_used_by_ct: dict[int, float | object] = {}
         self.scaledown_wait = scaledown_wait
 
-    def record_task_start(self, running_ct: int) -> None:
-        self._last_used_by_ct[running_ct] = self._SCALE_DOWN_BLOCKED
-
-    def record_task_finish(self, running_ct: int) -> None:
-        self._last_used_by_ct[running_ct] = time.monotonic()
-
-    def is_tracked(self, worker_ct: int) -> bool:
-        """Check if the tracker has a record for this worker count."""
-        return worker_ct in self._last_used_by_ct
-
     def fill_unknown_usage(self, worker_ct: int, running_ct: int) -> None:
-        """Lazy fallback for record_task_start / record_task_finish.
+        """Update the tracker with the current observed state of the pool.
 
-        Normally, every task start and finish records usage at the current
-        worker count via record_task_start / record_task_finish.  This keeps
-        the hot path fast (O(1) dict write, no traversals).  However, if a
-        recording is ever missed — e.g. due to a bug or a race — the tracker
-        may have no entry for the current worker count, leaving scale-down
-        unable to make a decision.
+        Called on every periodic scale-down check.  This is the sole input
+        mechanism for the tracker — there are no per-task hooks.  Avoiding
+        per-task recording eliminates a class of bugs where sentinels set
+        on the hot path are never cleared due to timing or count mismatches.
 
-        This method is the lazy corrective: called from the periodic
-        scale-down check only when a gap is detected.  It fills all missing
-        entries up to worker_ct based on current demand.  Keys at or below
-        running_ct are set to blocked (actively in use).  Keys above
-        running_ct are set to the current timestamp (idle surplus,
-        scale-down allowed after scaledown_wait).  Existing entries are
-        never overwritten.
+        For each worker-count key up to worker_ct:
+        - Keys at or below running_ct are set to blocked (actively in use),
+          regardless of previous state.
+        - Keys above running_ct that are absent or previously blocked are
+          set to the current timestamp (idle surplus, scale-down allowed
+          after scaledown_wait).
+        - Keys above running_ct that already have a timestamp are left
+          alone so they continue aging toward scaledown_wait.
         """
         now = time.monotonic()
         for ct in range(1, worker_ct + 1):
-            if ct not in self._last_used_by_ct:
-                if ct <= running_ct:
-                    self._last_used_by_ct[ct] = self._SCALE_DOWN_BLOCKED
-                    logger.warning(f'Backfilled missing usage entry for count {ct} as blocked (running_ct={running_ct})')
-                else:
-                    self._last_used_by_ct[ct] = now
-                    logger.warning(f'Backfilled missing usage entry for count {ct} as idle (running_ct={running_ct})')
+            if ct <= running_ct:
+                self._last_used_by_ct[ct] = self._SCALE_DOWN_BLOCKED
+            elif ct not in self._last_used_by_ct or self._last_used_by_ct[ct] is self._SCALE_DOWN_BLOCKED:
+                self._last_used_by_ct[ct] = now
 
     def should_scale_down(self, worker_ct: int) -> bool:
         if worker_ct not in self._last_used_by_ct:
@@ -437,9 +423,8 @@ class WorkerPool(WorkerPoolProtocol):
     def should_scale_down(self) -> bool:
         "If True, we have not had enough work lately to justify the number of workers we are running"
         worker_ct = len([worker for worker in self.workers if worker.counts_for_capacity])
-        if not self.usage_tracker.is_tracked(worker_ct):
-            running_ct = self.get_running_count()
-            self.usage_tracker.fill_unknown_usage(worker_ct, running_ct)
+        running_ct = self.get_running_count()
+        self.usage_tracker.fill_unknown_usage(worker_ct, running_ct)
         return self.usage_tracker.should_scale_down(worker_ct)
 
     async def scale_workers(self) -> int:
@@ -699,8 +684,6 @@ class WorkerPool(WorkerPoolProtocol):
     async def post_task_start(self, message: dict) -> None:
         if 'timeout' in message:
             await self.timeout_runner.kick()  # kick timeout task to set wakeup
-        running_ct = self.get_running_count()
-        self.usage_tracker.record_task_start(running_ct)
 
     async def dispatch_task(self, message: dict) -> None:
         uuid = message.get("uuid", "<unknown>")
@@ -751,9 +734,6 @@ class WorkerPool(WorkerPoolProtocol):
             else:
                 msg += f", result: {result}"
         logger.debug(msg)
-
-        running_ct = self.get_running_count()
-        self.usage_tracker.record_task_finish(running_ct)
 
         is_stopping = message.get('is_stopping', False)
 

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -22,6 +22,8 @@ from .process import ProcessManager, ProcessProxy
 
 logger = logging.getLogger(__name__)
 
+_SCALE_DOWN_BLOCKED = object()
+
 
 class PoolWorker(HasWakeup, PoolWorkerProtocol):
     def __init__(self, worker_id: int, process: ProcessProxy) -> None:
@@ -271,13 +273,16 @@ class WorkerPool(WorkerPoolProtocol):
 
         # Track the last time we used X number of workers, like
         # {
-        #   0: None,
-        #   1: None,
+        #   0: _SCALE_DOWN_BLOCKED,
+        #   1: _SCALE_DOWN_BLOCKED,
         #   2: <timestamp>
         # }
-        # where 1 worker is currently in use, and a task using the 2nd worker
-        # finished at <timestamp>, which is compared against out scale down wait time
-        self.last_used_by_ct: dict[int, float | None] = {}
+        # where 1 worker is currently in use (_SCALE_DOWN_BLOCKED means
+        # "actively running tasks, block scale-down"), and a task using the
+        # 2nd worker finished at <timestamp>, which is compared against our
+        # scale down wait time.  An absent key means we never needed that
+        # many workers, so scale-down is allowed immediately.
+        self.last_used_by_ct: dict[int, float | object] = {}
         self.scaledown_wait = scaledown_wait
         self.scaledown_interval = scaledown_interval  # seconds for poll to see if we should retire workers
         self.worker_stop_wait = worker_stop_wait  # seconds to wait for a worker to exit on its own before SIGTERM, SIGKILL
@@ -318,11 +323,22 @@ class WorkerPool(WorkerPoolProtocol):
         return self.processed_count + self.queuer.count() + self.blocker.count() + sum(1 for w in self.workers if w.current_task)
 
     def get_status_data(self) -> dict[str, Any]:
+        now = time.monotonic()
+        top5_keys = sorted(self.last_used_by_ct, reverse=True)[:5]
+        top5: dict[int, str | float] = {}
+        for k in top5_keys:
+            v = self.last_used_by_ct[k]
+            if v is _SCALE_DOWN_BLOCKED:
+                top5[k] = "blocked"
+            else:
+                top5[k] = round(now - v, 2)  # type: ignore[operator]
         return {
             "next_worker_id": self.next_worker_id,
             "finished_count": self.finished_count,
             "canceled_count": self.canceled_count,
             "retirement_count": self.retirement_count,
+            "last_used_by_ct_count": len(self.last_used_by_ct),
+            "last_used_by_ct_top5": top5,
         }
 
     async def start_working(self, dispatcher: DispatcherMain) -> None:
@@ -345,12 +361,16 @@ class WorkerPool(WorkerPoolProtocol):
     def should_scale_down(self) -> bool:
         "If True, we have not had enough work lately to justify the number of workers we are running"
         worker_ct = len([worker for worker in self.workers if worker.counts_for_capacity])
-        last_used = self.last_used_by_ct.get(worker_ct)
-        if last_used:
-            delta = time.monotonic() - last_used
-            # Criteria - last time we used this-many workers was greater than the setting
-            return bool(delta > self.scaledown_wait)
-        return False
+        if worker_ct not in self.last_used_by_ct:
+            # Never needed this many workers, scale down immediately
+            return True
+        last_used = self.last_used_by_ct[worker_ct]
+        if last_used is _SCALE_DOWN_BLOCKED:
+            # Currently in active use at this capacity, block scale-down
+            return False
+        # Check if idle long enough to justify scale-down
+        delta = time.monotonic() - last_used  # type: ignore[operator]
+        return bool(delta > self.scaledown_wait)
 
     async def scale_workers(self) -> int:
         """Initiates scale-up and scale-down actions
@@ -610,7 +630,7 @@ class WorkerPool(WorkerPoolProtocol):
         if 'timeout' in message:
             await self.timeout_runner.kick()  # kick timeout task to set wakeup
         running_ct = self.get_running_count()
-        self.last_used_by_ct[running_ct] = None  # block scale down of this amount
+        self.last_used_by_ct[running_ct] = _SCALE_DOWN_BLOCKED  # block scale down of this amount
 
     async def dispatch_task(self, message: dict) -> None:
         uuid = message.get("uuid", "<unknown>")

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -271,12 +271,20 @@ class WorkerUsageTracker:
           after scaledown_wait).
         - Keys above running_ct that already have a timestamp are left
           alone so they continue aging toward scaledown_wait.
+
+        Keys above worker_ct that are stale blocked entries (left over from
+        a previously higher worker count) are downgraded to the current
+        timestamp so they age out naturally instead of showing as blocked
+        in status output forever.
         """
         now = time.monotonic()
         for ct in range(1, worker_ct + 1):
             if ct <= running_ct:
                 self._last_used_by_ct[ct] = self._SCALE_DOWN_BLOCKED
             elif ct not in self._last_used_by_ct or self._last_used_by_ct[ct] is self._SCALE_DOWN_BLOCKED:
+                self._last_used_by_ct[ct] = now
+        for ct, value in self._last_used_by_ct.items():
+            if ct > worker_ct and value is self._SCALE_DOWN_BLOCKED:
                 self._last_used_by_ct[ct] = now
 
     def should_scale_down(self, worker_ct: int) -> bool:

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -328,7 +328,7 @@ class WorkerUsageTracker:
 
     def _near_worker_ct_summary(self, worker_ct: int) -> dict[int, str | float]:
         """Return _last_used_by_ct values for keys around the current worker count."""
-        keys = list(range(max(worker_ct - 2, 0), worker_ct + 3))
+        keys = list(range(max(worker_ct - 2, 1), worker_ct + 3))
         return self._format_entries(keys)
 
 

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -483,13 +483,16 @@ class WorkerPool(WorkerPoolProtocol):
             # Scale down above or to MIN, because surplus of workers have done nothing useful in <cutoff> time
             async with self.workers.management_lock:
                 # should_scale_down mutates usage_tracker — must be under lock (see also process_finished)
-                if self.should_scale_down():
-                    for worker in available_workers:
-                        if worker.current_task is None:
+                # Retire as many idle workers as should_scale_down() allows in one tick
+                while len([w for w in self.workers if w.counts_for_capacity]) > self.min_workers and self.should_scale_down():
+                    for worker in self.workers:
+                        if worker.counts_for_capacity and worker.current_task is None:
                             logger.info(f'Scaling down worker id={worker.worker_id} (prior ct={worker_ct}) due to demand')
                             await worker.signal_stop()
                             changed_ct -= 1
                             break
+                    else:
+                        break
 
         logger.debug(f'Ran scale_workers worker_ct={worker_ct}, active_task_ct={active_task_ct}, changed {changed_ct}')
         return changed_ct

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -445,17 +445,6 @@ class WorkerPool(WorkerPoolProtocol):
                 ct += 1
         return ct
 
-    def should_scale_down(self) -> bool:
-        """If True, we have not had enough work lately to justify the number of workers we are running.
-
-        Must be called under management_lock — mutates usage_tracker state.
-        See also process_finished, which records usage under the same lock.
-        """
-        worker_ct = len([worker for worker in self.workers if worker.counts_for_capacity])
-        demand_ct = self.active_task_ct()
-        self.usage_tracker.fill_unknown_usage(worker_ct, demand_ct)
-        return self.usage_tracker.should_scale_down(worker_ct, demand_ct)
-
     async def scale_workers(self) -> int:
         """Initiates scale-up and scale-down actions
 
@@ -494,21 +483,40 @@ class WorkerPool(WorkerPoolProtocol):
             pass
 
         elif worker_ct > self.min_workers:
-            # Scale down above or to MIN, because surplus of workers have done nothing useful in <cutoff> time
-            async with self.workers.management_lock:
-                # should_scale_down mutates usage_tracker — must be under lock (see also process_finished)
-                # Retire as many idle workers as should_scale_down() allows in one tick
-                while len([w for w in self.workers if w.counts_for_capacity]) > self.min_workers and self.should_scale_down():
-                    for worker in self.workers:
-                        if worker.counts_for_capacity and worker.current_task is None:
-                            logger.info(f'Scaling down worker id={worker.worker_id} (prior ct={worker_ct}) due to demand')
-                            await worker.signal_stop()
-                            changed_ct -= 1
-                            break
-                    else:
-                        break
+            changed_ct = await self._scale_down(worker_ct)
 
         logger.debug(f'Ran scale_workers worker_ct={worker_ct}, active_task_ct={active_task_ct}, changed {changed_ct}')
+        return changed_ct
+
+    async def _scale_down(self, prior_worker_ct: int) -> int:
+        """Retire idle workers down to demand + reserve, respecting min_workers.
+
+        Returns a negative count of workers that were sent stop signals.
+        Must not be called if worker_ct <= min_workers.
+        """
+        max_scaledown_per_tick = 300
+        changed_ct = 0
+        async with self.workers.management_lock:
+            # fill_unknown_usage mutates usage_tracker — must be under lock (see also process_finished)
+            # Fill once; demand_ct does not change under the lock
+            demand_ct = self.active_task_ct()
+            capacity_ct = len([w for w in self.workers if w.counts_for_capacity])
+            self.usage_tracker.fill_unknown_usage(capacity_ct, demand_ct)
+            scaled = 0
+            while capacity_ct > self.min_workers and self.usage_tracker.should_scale_down(capacity_ct, demand_ct):
+                if scaled >= max_scaledown_per_tick:
+                    logger.warning(f'Reached scale-down limit of {max_scaledown_per_tick} in a single tick, deferring remaining to next tick')
+                    break
+                for worker in self.workers:
+                    if worker.counts_for_capacity and worker.current_task is None:
+                        logger.info(f'Scaling down worker id={worker.worker_id} (prior ct={prior_worker_ct}) due to demand')
+                        await worker.signal_stop()
+                        changed_ct -= 1
+                        capacity_ct -= 1
+                        scaled += 1
+                        break
+                else:
+                    break
         return changed_ct
 
     async def manage_new_workers(self) -> None:

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -322,27 +322,39 @@ class WorkerPool(WorkerPoolProtocol):
     def received_count(self) -> int:
         return self.processed_count + self.queuer.count() + self.blocker.count() + sum(1 for w in self.workers if w.current_task)
 
+    def _last_used_summary(self, keys: list[int]) -> dict[int, str | float]:
+        """Return human-readable last_used_by_ct values for the given keys."""
+        now = time.monotonic()
+        result: dict[int, str | float] = {}
+        for k in keys:
+            if k not in self.last_used_by_ct:
+                result[k] = "absent"
+            elif self.last_used_by_ct[k] is _SCALE_DOWN_BLOCKED:
+                result[k] = "blocked"
+            else:
+                result[k] = round(now - self.last_used_by_ct[k], 2)  # type: ignore[operator]
+        return result
+
     def _last_used_top5_summary(self) -> dict[int, str | float]:
         """Return the 5 highest worker-count entries from last_used_by_ct, with human-readable values."""
-        now = time.monotonic()
-        top5: dict[int, str | float] = {}
-        for k in sorted(self.last_used_by_ct, reverse=True)[:5]:
-            v = self.last_used_by_ct[k]
-            if v is _SCALE_DOWN_BLOCKED:
-                top5[k] = "blocked"
-            else:
-                top5[k] = round(now - v, 2)  # type: ignore[operator]
-        return top5
+        return self._last_used_summary(sorted(self.last_used_by_ct, reverse=True)[:5])
+
+    def _last_used_near_worker_ct_summary(self, worker_ct: int) -> dict[int, str | float]:
+        """Return last_used_by_ct values for keys around the current worker count."""
+        keys = list(range(max(worker_ct - 2, 0), worker_ct + 3))
+        return self._last_used_summary(keys)
 
     def get_status_data(self) -> dict[str, Any]:
+        worker_ct = len([worker for worker in self.workers if worker.counts_for_capacity])
         return {
             "next_worker_id": self.next_worker_id,
             "finished_count": self.finished_count,
             "canceled_count": self.canceled_count,
             "retirement_count": self.retirement_count,
-            "worker_ct": len([worker for worker in self.workers if worker.counts_for_capacity]),
+            "worker_ct": worker_ct,
             "last_used_by_ct_count": len(self.last_used_by_ct),
             "last_used_by_ct_top5": self._last_used_top5_summary(),
+            "last_used_near_worker_ct": self._last_used_near_worker_ct_summary(worker_ct),
         }
 
     async def start_working(self, dispatcher: DispatcherMain) -> None:
@@ -368,7 +380,8 @@ class WorkerPool(WorkerPoolProtocol):
         if worker_ct not in self.last_used_by_ct:
             # Never needed this many workers, scale down immediately
             logger.info(
-                f'No record of needing {worker_ct} workers, allowing scale-down (worker count exceeded tracked usage, top5={self._last_used_top5_summary()})'
+                f'No record of needing {worker_ct} workers, allowing scale-down'
+                f' (worker count exceeded tracked usage, near={self._last_used_near_worker_ct_summary(worker_ct)})'
             )
             return True
         last_used = self.last_used_by_ct[worker_ct]

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -22,8 +22,6 @@ from .process import ProcessManager, ProcessProxy
 
 logger = logging.getLogger(__name__)
 
-_SCALE_DOWN_BLOCKED = object()
-
 
 class PoolWorker(HasWakeup, PoolWorkerProtocol):
     def __init__(self, worker_id: int, process: ProcessProxy) -> None:
@@ -231,6 +229,70 @@ class WorkerData(WorkerDataProtocol):
             logger.warning(f'Attempted to move worker_id={worker_id} to end, but worker was already removed from workers dict')
 
 
+class WorkerUsageTracker:
+    """Tracks when the pool last needed N concurrent workers, for scale-down decisions.
+
+    Three states per worker-count key:
+    - absent:  never needed this many → scale down immediately
+    - _SCALE_DOWN_BLOCKED:  actively in use → block scale-down
+    - float timestamp:  last finished at this count → scale down if idle > scaledown_wait
+    """
+
+    _SCALE_DOWN_BLOCKED = object()
+
+    def __init__(self, scaledown_wait: float) -> None:
+        self._last_used_by_ct: dict[int, float | object] = {}
+        self.scaledown_wait = scaledown_wait
+
+    def record_task_start(self, running_ct: int) -> None:
+        self._last_used_by_ct[running_ct] = self._SCALE_DOWN_BLOCKED
+
+    def record_task_finish(self, running_ct: int) -> None:
+        self._last_used_by_ct[running_ct] = time.monotonic()
+
+    def should_scale_down(self, worker_ct: int) -> bool:
+        if worker_ct not in self._last_used_by_ct:
+            logger.info(
+                f'No record of needing {worker_ct} workers, allowing scale-down'
+                f' (worker count exceeded tracked usage, near={self._near_worker_ct_summary(worker_ct)})'
+            )
+            return True
+        last_used = self._last_used_by_ct[worker_ct]
+        if last_used is self._SCALE_DOWN_BLOCKED:
+            return False
+        delta = time.monotonic() - last_used  # type: ignore[operator]
+        return bool(delta > self.scaledown_wait)
+
+    def get_status_data(self, worker_ct: int) -> dict:
+        return {
+            "count": len(self._last_used_by_ct),
+            "top5": self._top5_summary(),
+            "near_worker_ct": self._near_worker_ct_summary(worker_ct),
+        }
+
+    def _format_entries(self, keys: list[int]) -> dict[int, str | float]:
+        """Return human-readable _last_used_by_ct values for the given keys."""
+        now = time.monotonic()
+        result: dict[int, str | float] = {}
+        for k in keys:
+            if k not in self._last_used_by_ct:
+                result[k] = "absent"
+            elif self._last_used_by_ct[k] is self._SCALE_DOWN_BLOCKED:
+                result[k] = "blocked"
+            else:
+                result[k] = round(now - self._last_used_by_ct[k], 2)  # type: ignore[operator]
+        return result
+
+    def _top5_summary(self) -> dict[int, str | float]:
+        """Return the 5 highest worker-count entries from _last_used_by_ct, with human-readable values."""
+        return self._format_entries(sorted(self._last_used_by_ct, reverse=True)[:5])
+
+    def _near_worker_ct_summary(self, worker_ct: int) -> dict[int, str | float]:
+        """Return _last_used_by_ct values for keys around the current worker count."""
+        keys = list(range(max(worker_ct - 2, 0), worker_ct + 3))
+        return self._format_entries(keys)
+
+
 class WorkerPool(WorkerPoolProtocol):
     def __init__(
         self,
@@ -271,19 +333,7 @@ class WorkerPool(WorkerPoolProtocol):
         # the timeout runner keeps its own task
         self.timeout_runner = NextWakeupRunner(self.workers, self.cancel_worker, shared=shared, name='worker_timeout_manager')
 
-        # Track the last time we used X number of workers, like
-        # {
-        #   0: _SCALE_DOWN_BLOCKED,
-        #   1: _SCALE_DOWN_BLOCKED,
-        #   2: <timestamp>
-        # }
-        # where 1 worker is currently in use (_SCALE_DOWN_BLOCKED means
-        # "actively running tasks, block scale-down"), and a task using the
-        # 2nd worker finished at <timestamp>, which is compared against our
-        # scale down wait time.  An absent key means we never needed that
-        # many workers, so scale-down is allowed immediately.
-        self.last_used_by_ct: dict[int, float | object] = {}
-        self.scaledown_wait = scaledown_wait
+        self.usage_tracker = WorkerUsageTracker(scaledown_wait=scaledown_wait)
         self.scaledown_interval = scaledown_interval  # seconds for poll to see if we should retire workers
         self.worker_stop_wait = worker_stop_wait  # seconds to wait for a worker to exit on its own before SIGTERM, SIGKILL
         self.worker_removal_wait = worker_removal_wait  # after worker process exits, seconds to keep its record, for stats
@@ -322,28 +372,6 @@ class WorkerPool(WorkerPoolProtocol):
     def received_count(self) -> int:
         return self.processed_count + self.queuer.count() + self.blocker.count() + sum(1 for w in self.workers if w.current_task)
 
-    def _last_used_summary(self, keys: list[int]) -> dict[int, str | float]:
-        """Return human-readable last_used_by_ct values for the given keys."""
-        now = time.monotonic()
-        result: dict[int, str | float] = {}
-        for k in keys:
-            if k not in self.last_used_by_ct:
-                result[k] = "absent"
-            elif self.last_used_by_ct[k] is _SCALE_DOWN_BLOCKED:
-                result[k] = "blocked"
-            else:
-                result[k] = round(now - self.last_used_by_ct[k], 2)  # type: ignore[operator]
-        return result
-
-    def _last_used_top5_summary(self) -> dict[int, str | float]:
-        """Return the 5 highest worker-count entries from last_used_by_ct, with human-readable values."""
-        return self._last_used_summary(sorted(self.last_used_by_ct, reverse=True)[:5])
-
-    def _last_used_near_worker_ct_summary(self, worker_ct: int) -> dict[int, str | float]:
-        """Return last_used_by_ct values for keys around the current worker count."""
-        keys = list(range(max(worker_ct - 2, 0), worker_ct + 3))
-        return self._last_used_summary(keys)
-
     def get_status_data(self) -> dict[str, Any]:
         worker_ct = len([worker for worker in self.workers if worker.counts_for_capacity])
         return {
@@ -352,9 +380,7 @@ class WorkerPool(WorkerPoolProtocol):
             "canceled_count": self.canceled_count,
             "retirement_count": self.retirement_count,
             "worker_ct": worker_ct,
-            "last_used_by_ct_count": len(self.last_used_by_ct),
-            "last_used_by_ct_top5": self._last_used_top5_summary(),
-            "last_used_near_worker_ct": self._last_used_near_worker_ct_summary(worker_ct),
+            "usage": self.usage_tracker.get_status_data(worker_ct),
         }
 
     async def start_working(self, dispatcher: DispatcherMain) -> None:
@@ -377,20 +403,7 @@ class WorkerPool(WorkerPoolProtocol):
     def should_scale_down(self) -> bool:
         "If True, we have not had enough work lately to justify the number of workers we are running"
         worker_ct = len([worker for worker in self.workers if worker.counts_for_capacity])
-        if worker_ct not in self.last_used_by_ct:
-            # Never needed this many workers, scale down immediately
-            logger.info(
-                f'No record of needing {worker_ct} workers, allowing scale-down'
-                f' (worker count exceeded tracked usage, near={self._last_used_near_worker_ct_summary(worker_ct)})'
-            )
-            return True
-        last_used = self.last_used_by_ct[worker_ct]
-        if last_used is _SCALE_DOWN_BLOCKED:
-            # Currently in active use at this capacity, block scale-down
-            return False
-        # Check if idle long enough to justify scale-down
-        delta = time.monotonic() - last_used  # type: ignore[operator]
-        return bool(delta > self.scaledown_wait)
+        return self.usage_tracker.should_scale_down(worker_ct)
 
     async def scale_workers(self) -> int:
         """Initiates scale-up and scale-down actions
@@ -650,7 +663,7 @@ class WorkerPool(WorkerPoolProtocol):
         if 'timeout' in message:
             await self.timeout_runner.kick()  # kick timeout task to set wakeup
         running_ct = self.get_running_count()
-        self.last_used_by_ct[running_ct] = _SCALE_DOWN_BLOCKED  # block scale down of this amount
+        self.usage_tracker.record_task_start(running_ct)
 
     async def dispatch_task(self, message: dict) -> None:
         uuid = message.get("uuid", "<unknown>")
@@ -703,7 +716,7 @@ class WorkerPool(WorkerPoolProtocol):
         logger.debug(msg)
 
         running_ct = self.get_running_count()
-        self.last_used_by_ct[running_ct] = time.monotonic()  # scale down may be allowed, clock starting now
+        self.usage_tracker.record_task_finish(running_ct)
 
         is_stopping = message.get('is_stopping', False)
 

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -244,13 +244,24 @@ class WorkerUsageTracker:
         self._last_used_by_ct: dict[int, float | object] = {}
         self.scaledown_wait = scaledown_wait
 
+    def record_task_finish(self, running_ct: int) -> None:
+        """Record a timestamp when a task finishes at the given running count.
+
+        Called from the task-completion hot path.  This is the only per-task
+        hook — there is no corresponding record_task_start because blocking
+        is handled entirely by the periodic fill_unknown_usage.  Recording
+        the finish timestamp allows scale-down to proceed at the earliest
+        possible moment rather than waiting for the next periodic tick.
+        """
+        self._last_used_by_ct[running_ct] = time.monotonic()
+
     def fill_unknown_usage(self, worker_ct: int, running_ct: int) -> None:
         """Update the tracker with the current observed state of the pool.
 
-        Called on every periodic scale-down check.  This is the sole input
-        mechanism for the tracker — there are no per-task hooks.  Avoiding
-        per-task recording eliminates a class of bugs where sentinels set
-        on the hot path are never cleared due to timing or count mismatches.
+        Called on every periodic scale-down check.  This is the primary input
+        mechanism for blocking scale-down — keys at or below the current load
+        are marked as blocked.  record_task_finish provides the complementary
+        timestamp recording on the hot path for timely scale-down.
 
         For each worker-count key up to worker_ct:
         - Keys at or below running_ct are set to blocked (actively in use),
@@ -421,7 +432,11 @@ class WorkerPool(WorkerPoolProtocol):
         return ct
 
     def should_scale_down(self) -> bool:
-        "If True, we have not had enough work lately to justify the number of workers we are running"
+        """If True, we have not had enough work lately to justify the number of workers we are running.
+
+        Must be called under management_lock — mutates usage_tracker state.
+        See also process_finished, which records usage under the same lock.
+        """
         worker_ct = len([worker for worker in self.workers if worker.counts_for_capacity])
         running_ct = self.get_running_count()
         self.usage_tracker.fill_unknown_usage(worker_ct, running_ct)
@@ -467,6 +482,7 @@ class WorkerPool(WorkerPoolProtocol):
         elif worker_ct > self.min_workers:
             # Scale down above or to MIN, because surplus of workers have done nothing useful in <cutoff> time
             async with self.workers.management_lock:
+                # should_scale_down mutates usage_tracker — must be under lock (see also process_finished)
                 if self.should_scale_down():
                     for worker in available_workers:
                         if worker.current_task is None:
@@ -749,6 +765,11 @@ class WorkerPool(WorkerPoolProtocol):
                     worker.stopping_at = time.monotonic()
             worker.mark_finished_task()
             self.workers.move_to_end(worker.worker_id)
+            # Record usage after mark_finished_task clears current_task,
+            # so get_running_count reflects the post-finish state.
+            # Must be under management_lock — see also scale_workers and should_scale_down.
+            running_ct = self.get_running_count()
+            self.usage_tracker.record_task_finish(running_ct)
 
         if not self.queuer.queued_messages and all(worker.current_task is None for worker in self.workers):
             self.events.work_cleared.set()

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -322,23 +322,27 @@ class WorkerPool(WorkerPoolProtocol):
     def received_count(self) -> int:
         return self.processed_count + self.queuer.count() + self.blocker.count() + sum(1 for w in self.workers if w.current_task)
 
-    def get_status_data(self) -> dict[str, Any]:
+    def _last_used_top5_summary(self) -> dict[int, str | float]:
+        """Return the 5 highest worker-count entries from last_used_by_ct, with human-readable values."""
         now = time.monotonic()
-        top5_keys = sorted(self.last_used_by_ct, reverse=True)[:5]
         top5: dict[int, str | float] = {}
-        for k in top5_keys:
+        for k in sorted(self.last_used_by_ct, reverse=True)[:5]:
             v = self.last_used_by_ct[k]
             if v is _SCALE_DOWN_BLOCKED:
                 top5[k] = "blocked"
             else:
                 top5[k] = round(now - v, 2)  # type: ignore[operator]
+        return top5
+
+    def get_status_data(self) -> dict[str, Any]:
         return {
             "next_worker_id": self.next_worker_id,
             "finished_count": self.finished_count,
             "canceled_count": self.canceled_count,
             "retirement_count": self.retirement_count,
+            "worker_ct": len([worker for worker in self.workers if worker.counts_for_capacity]),
             "last_used_by_ct_count": len(self.last_used_by_ct),
-            "last_used_by_ct_top5": top5,
+            "last_used_by_ct_top5": self._last_used_top5_summary(),
         }
 
     async def start_working(self, dispatcher: DispatcherMain) -> None:
@@ -363,7 +367,9 @@ class WorkerPool(WorkerPoolProtocol):
         worker_ct = len([worker for worker in self.workers if worker.counts_for_capacity])
         if worker_ct not in self.last_used_by_ct:
             # Never needed this many workers, scale down immediately
-            logger.info(f'No record of needing {worker_ct} workers, allowing scale-down (worker count exceeded tracked usage)')
+            logger.info(
+                f'No record of needing {worker_ct} workers, allowing scale-down (worker count exceeded tracked usage, top5={self._last_used_top5_summary()})'
+            )
             return True
         last_used = self.last_used_by_ct[worker_ct]
         if last_used is _SCALE_DOWN_BLOCKED:

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -423,6 +423,8 @@ class WorkerPool(WorkerPoolProtocol):
             "canceled_count": self.canceled_count,
             "retirement_count": self.retirement_count,
             "worker_ct": worker_ct,
+            "running_ct": self.get_running_count(),
+            "active_task_ct": self.active_task_ct(),
             "usage": self.usage_tracker.get_status_data(worker_ct),
         }
 
@@ -450,9 +452,9 @@ class WorkerPool(WorkerPoolProtocol):
         See also process_finished, which records usage under the same lock.
         """
         worker_ct = len([worker for worker in self.workers if worker.counts_for_capacity])
-        running_ct = self.get_running_count()
-        self.usage_tracker.fill_unknown_usage(worker_ct, running_ct)
-        return self.usage_tracker.should_scale_down(worker_ct, running_ct)
+        demand_ct = self.active_task_ct()
+        self.usage_tracker.fill_unknown_usage(worker_ct, demand_ct)
+        return self.usage_tracker.should_scale_down(worker_ct, demand_ct)
 
     async def scale_workers(self) -> int:
         """Initiates scale-up and scale-down actions
@@ -781,10 +783,9 @@ class WorkerPool(WorkerPoolProtocol):
             worker.mark_finished_task()
             self.workers.move_to_end(worker.worker_id)
             # Record usage after mark_finished_task clears current_task,
-            # so get_running_count reflects the post-finish state.
+            # so active_task_ct reflects the post-finish state.
             # Must be under management_lock — see also scale_workers and should_scale_down.
-            running_ct = self.get_running_count()
-            self.usage_tracker.record_task_finish(running_ct)
+            self.usage_tracker.record_task_finish(self.active_task_ct())
 
         if not self.queuer.queued_messages and all(worker.current_task is None for worker in self.workers):
             self.events.work_cleared.set()

--- a/dispatcherd/service/pool.py
+++ b/dispatcherd/service/pool.py
@@ -240,9 +240,10 @@ class WorkerUsageTracker:
 
     _SCALE_DOWN_BLOCKED = object()
 
-    def __init__(self, scaledown_wait: float) -> None:
+    def __init__(self, scaledown_wait: float, scaledown_reserve: int = 0) -> None:
         self._last_used_by_ct: dict[int, float | object] = {}
         self.scaledown_wait = scaledown_wait
+        self.scaledown_reserve = scaledown_reserve
 
     def record_task_finish(self, running_ct: int) -> None:
         """Record a timestamp when a task finishes at the given running count.
@@ -287,7 +288,7 @@ class WorkerUsageTracker:
             if ct > worker_ct and value is self._SCALE_DOWN_BLOCKED:
                 self._last_used_by_ct[ct] = now
 
-    def should_scale_down(self, worker_ct: int) -> bool:
+    def should_scale_down(self, worker_ct: int, running_ct: int = 0) -> bool:
         if worker_ct not in self._last_used_by_ct:
             logger.warning(
                 f'No record of needing {worker_ct} workers, allowing scale-down'
@@ -296,6 +297,8 @@ class WorkerUsageTracker:
             return True
         last_used = self._last_used_by_ct[worker_ct]
         if last_used is self._SCALE_DOWN_BLOCKED:
+            return False
+        if self.scaledown_reserve and worker_ct <= running_ct + self.scaledown_reserve:
             return False
         delta = time.monotonic() - last_used  # type: ignore[operator]
         return bool(delta > self.scaledown_wait)
@@ -341,6 +344,7 @@ class WorkerPool(WorkerPoolProtocol):
         max_workers: int | None = None,
         scaledown_wait: float = 15.0,
         scaledown_interval: float = 15.0,
+        scaledown_reserve: int = 0,
         worker_stop_wait: float = 30.0,
         worker_removal_wait: float = 30.0,
         worker_max_lifetime_seconds: float | None = 4 * 60 * 60,
@@ -372,7 +376,7 @@ class WorkerPool(WorkerPoolProtocol):
         # the timeout runner keeps its own task
         self.timeout_runner = NextWakeupRunner(self.workers, self.cancel_worker, shared=shared, name='worker_timeout_manager')
 
-        self.usage_tracker = WorkerUsageTracker(scaledown_wait=scaledown_wait)
+        self.usage_tracker = WorkerUsageTracker(scaledown_wait=scaledown_wait, scaledown_reserve=scaledown_reserve)
         self.scaledown_interval = scaledown_interval  # seconds for poll to see if we should retire workers
         self.worker_stop_wait = worker_stop_wait  # seconds to wait for a worker to exit on its own before SIGTERM, SIGKILL
         self.worker_removal_wait = worker_removal_wait  # after worker process exits, seconds to keep its record, for stats
@@ -448,7 +452,7 @@ class WorkerPool(WorkerPoolProtocol):
         worker_ct = len([worker for worker in self.workers if worker.counts_for_capacity])
         running_ct = self.get_running_count()
         self.usage_tracker.fill_unknown_usage(worker_ct, running_ct)
-        return self.usage_tracker.should_scale_down(worker_ct)
+        return self.usage_tracker.should_scale_down(worker_ct, running_ct)
 
     async def scale_workers(self) -> int:
         """Initiates scale-up and scale-down actions

--- a/schema.json
+++ b/schema.json
@@ -34,6 +34,7 @@
       "max_workers": "int | None",
       "scaledown_wait": "<class 'float'>",
       "scaledown_interval": "<class 'float'>",
+      "scaledown_reserve": "<class 'int'>",
       "worker_stop_wait": "<class 'float'>",
       "worker_removal_wait": "<class 'float'>",
       "worker_max_lifetime_seconds": "float | None",

--- a/tests/unit/service/test_usage_tracker.py
+++ b/tests/unit/service/test_usage_tracker.py
@@ -135,6 +135,40 @@ class TestFillAndScaleDown:
         assert tracker.should_scale_down(2) is False
         assert tracker.should_scale_down(3) is True
 
+    def test_scaledown_reserve_blocks_within_buffer(self):
+        """With scaledown_reserve=2, worker_ct 6 with running_ct 4 should not scale down (6 <= 4+2)."""
+        tracker = WorkerUsageTracker(scaledown_wait=10.0, scaledown_reserve=2)
+        base = 1000.0
+        with patch('time.monotonic', return_value=base):
+            tracker.fill_unknown_usage(worker_ct=6, running_ct=4)
+        # After scaledown_wait, worker_ct=6 is within reserve (6 <= 4+2)
+        with patch('time.monotonic', return_value=base + 11.0):
+            assert tracker.should_scale_down(6, running_ct=4) is False
+        # Absent key still returns True (absent overrides reserve)
+        with patch('time.monotonic', return_value=base + 11.0):
+            assert tracker.should_scale_down(7, running_ct=4) is True
+
+    def test_scaledown_reserve_allows_beyond_buffer(self):
+        """With scaledown_reserve=2, worker_ct above running_ct+reserve can scale down."""
+        tracker = WorkerUsageTracker(scaledown_wait=10.0, scaledown_reserve=2)
+        base = 1000.0
+        with patch('time.monotonic', return_value=base):
+            tracker.fill_unknown_usage(worker_ct=8, running_ct=4)
+        with patch('time.monotonic', return_value=base + 11.0):
+            assert tracker.should_scale_down(8, running_ct=4) is True  # 8 > 4+2
+            assert tracker.should_scale_down(7, running_ct=4) is True  # 7 > 4+2
+            assert tracker.should_scale_down(6, running_ct=4) is False  # 6 <= 4+2
+
+    def test_scaledown_reserve_zero_default(self):
+        """With default scaledown_reserve=0, behavior matches existing tests."""
+        tracker = WorkerUsageTracker(scaledown_wait=10.0)
+        assert tracker.scaledown_reserve == 0
+        base = 1000.0
+        with patch('time.monotonic', return_value=base):
+            tracker.fill_unknown_usage(worker_ct=3, running_ct=0)
+        with patch('time.monotonic', return_value=base + 11.0):
+            assert tracker.should_scale_down(3) is True
+
     def test_stale_blocked_entries_above_worker_ct_downgraded(self):
         """Keys above worker_ct left over from a previously higher worker count
         should be downgraded from blocked to a timestamp so they age out."""

--- a/tests/unit/service/test_usage_tracker.py
+++ b/tests/unit/service/test_usage_tracker.py
@@ -22,7 +22,7 @@ class TestRecordTaskFinish:
     def test_finish_overwrites_blocked_entry(self):
         """record_task_finish replaces a blocked sentinel with a timestamp."""
         tracker = WorkerUsageTracker(scaledown_wait=10.0)
-        tracker.fill_unknown_usage(worker_ct=3, running_ct=3)
+        tracker.fill_unknown_usage(worker_ct=3, demand_ct=3)
         assert tracker.should_scale_down(3) is False
         # Task finishes — replaces blocked with timestamp
         base = 1000.0
@@ -45,7 +45,7 @@ class TestRecordTaskFinish:
             tracker.record_task_finish(5)
         # Periodic fill at base+5 — should NOT overwrite the older timestamp
         with patch('time.monotonic', return_value=base + 5.0):
-            tracker.fill_unknown_usage(worker_ct=5, running_ct=0)
+            tracker.fill_unknown_usage(worker_ct=5, demand_ct=0)
         # At base+11, the record_task_finish timestamp is old enough
         with patch('time.monotonic', return_value=base + 11.0):
             assert tracker.should_scale_down(5) is True
@@ -57,17 +57,17 @@ class TestFillAndScaleDown:
         assert tracker.should_scale_down(5) is True
 
     def test_active_load_blocks_scale_down(self):
-        """Keys at or below running_ct are blocked."""
+        """Keys at or below demand_ct are blocked."""
         tracker = WorkerUsageTracker(scaledown_wait=15.0)
-        tracker.fill_unknown_usage(worker_ct=3, running_ct=3)
+        tracker.fill_unknown_usage(worker_ct=3, demand_ct=3)
         assert tracker.should_scale_down(3) is False
 
     def test_idle_surplus_blocks_until_scaledown_wait(self):
-        """Keys above running_ct get a fresh timestamp — blocked until scaledown_wait passes."""
+        """Keys above demand_ct get a fresh timestamp — blocked until scaledown_wait passes."""
         tracker = WorkerUsageTracker(scaledown_wait=10.0)
         base = 1000.0
         with patch('time.monotonic', return_value=base):
-            tracker.fill_unknown_usage(worker_ct=3, running_ct=0)
+            tracker.fill_unknown_usage(worker_ct=3, demand_ct=0)
         with patch('time.monotonic', return_value=base):
             assert tracker.should_scale_down(3) is False
         with patch('time.monotonic', return_value=base + 11.0):
@@ -77,7 +77,7 @@ class TestFillAndScaleDown:
         tracker = WorkerUsageTracker(scaledown_wait=10.0)
         base = 1000.0
         with patch('time.monotonic', return_value=base):
-            tracker.fill_unknown_usage(worker_ct=3, running_ct=0)
+            tracker.fill_unknown_usage(worker_ct=3, demand_ct=0)
         # Just under the wait threshold — should block
         with patch('time.monotonic', return_value=base + 9.0):
             assert tracker.should_scale_down(3) is False
@@ -86,78 +86,78 @@ class TestFillAndScaleDown:
             assert tracker.should_scale_down(3) is True
 
     def test_blocked_entries_refresh_when_still_active(self):
-        """Repeated fills with same running_ct keep entries blocked."""
+        """Repeated fills with same demand_ct keep entries blocked."""
         tracker = WorkerUsageTracker(scaledown_wait=15.0)
-        tracker.fill_unknown_usage(worker_ct=3, running_ct=3)
+        tracker.fill_unknown_usage(worker_ct=3, demand_ct=3)
         assert tracker.should_scale_down(3) is False
         # Second fill, still loaded
-        tracker.fill_unknown_usage(worker_ct=3, running_ct=3)
+        tracker.fill_unknown_usage(worker_ct=3, demand_ct=3)
         assert tracker.should_scale_down(3) is False
 
     def test_blocked_entries_convert_to_timestamp_when_idle(self):
-        """When running_ct drops, previously blocked entries above it
+        """When demand_ct drops, previously blocked entries above it
         are replaced with a timestamp and start aging."""
         tracker = WorkerUsageTracker(scaledown_wait=10.0)
         base = 1000.0
         # First fill: all 3 keys blocked
-        tracker.fill_unknown_usage(worker_ct=3, running_ct=3)
+        tracker.fill_unknown_usage(worker_ct=3, demand_ct=3)
         assert tracker.should_scale_down(3) is False
 
-        # Second fill: running_ct dropped, key 3 was blocked but now idle
+        # Second fill: demand_ct dropped, key 3 was blocked but now idle
         with patch('time.monotonic', return_value=base):
-            tracker.fill_unknown_usage(worker_ct=3, running_ct=1)
+            tracker.fill_unknown_usage(worker_ct=3, demand_ct=1)
         # Key 3 now has a timestamp, but too recent
         with patch('time.monotonic', return_value=base):
             assert tracker.should_scale_down(3) is False
         # After scaledown_wait, key 3 allows scale-down
         with patch('time.monotonic', return_value=base + 11.0):
             assert tracker.should_scale_down(3) is True
-        # Key 1 is still blocked (at running_ct)
+        # Key 1 is still blocked (at demand_ct)
         with patch('time.monotonic', return_value=base + 11.0):
             assert tracker.should_scale_down(1) is False
 
     def test_existing_timestamps_not_overwritten_by_fill(self):
-        """Timestamps above running_ct are preserved so they keep aging."""
+        """Timestamps above demand_ct are preserved so they keep aging."""
         tracker = WorkerUsageTracker(scaledown_wait=10.0)
         base = 1000.0
         with patch('time.monotonic', return_value=base):
-            tracker.fill_unknown_usage(worker_ct=3, running_ct=0)
+            tracker.fill_unknown_usage(worker_ct=3, demand_ct=0)
         # Second fill much later — timestamps should NOT be refreshed
         with patch('time.monotonic', return_value=base + 100.0):
-            tracker.fill_unknown_usage(worker_ct=3, running_ct=0)
+            tracker.fill_unknown_usage(worker_ct=3, demand_ct=0)
         # Original timestamps are preserved, so they're old enough
         with patch('time.monotonic', return_value=base + 11.0):
             assert tracker.should_scale_down(3) is True
 
     def test_different_worker_counts_independent(self):
         tracker = WorkerUsageTracker(scaledown_wait=15.0)
-        tracker.fill_unknown_usage(worker_ct=2, running_ct=2)
+        tracker.fill_unknown_usage(worker_ct=2, demand_ct=2)
         assert tracker.should_scale_down(2) is False
         assert tracker.should_scale_down(3) is True
 
     def test_scaledown_reserve_blocks_within_buffer(self):
-        """With scaledown_reserve=2, worker_ct 6 with running_ct 4 should not scale down (6 <= 4+2)."""
+        """With scaledown_reserve=2, worker_ct 6 with demand_ct 4 should not scale down (6 <= 4+2)."""
         tracker = WorkerUsageTracker(scaledown_wait=10.0, scaledown_reserve=2)
         base = 1000.0
         with patch('time.monotonic', return_value=base):
-            tracker.fill_unknown_usage(worker_ct=6, running_ct=4)
+            tracker.fill_unknown_usage(worker_ct=6, demand_ct=4)
         # After scaledown_wait, worker_ct=6 is within reserve (6 <= 4+2)
         with patch('time.monotonic', return_value=base + 11.0):
-            assert tracker.should_scale_down(6, running_ct=4) is False
+            assert tracker.should_scale_down(6, demand_ct=4) is False
         # Absent key still returns True (absent overrides reserve)
         with patch('time.monotonic', return_value=base + 11.0):
-            assert tracker.should_scale_down(7, running_ct=4) is True
+            assert tracker.should_scale_down(7, demand_ct=4) is True
 
     def test_scaledown_reserve_allows_beyond_buffer(self):
-        """With scaledown_reserve=2, worker_ct above running_ct+reserve can scale down."""
+        """With scaledown_reserve=2, worker_ct above demand_ct+reserve can scale down."""
         tracker = WorkerUsageTracker(scaledown_wait=10.0, scaledown_reserve=2)
         base = 1000.0
         with patch('time.monotonic', return_value=base):
-            tracker.fill_unknown_usage(worker_ct=8, running_ct=4)
+            tracker.fill_unknown_usage(worker_ct=8, demand_ct=4)
         with patch('time.monotonic', return_value=base + 11.0):
-            assert tracker.should_scale_down(8, running_ct=4) is True  # 8 > 4+2
-            assert tracker.should_scale_down(7, running_ct=4) is True  # 7 > 4+2
-            assert tracker.should_scale_down(6, running_ct=4) is False  # 6 <= 4+2
+            assert tracker.should_scale_down(8, demand_ct=4) is True  # 8 > 4+2
+            assert tracker.should_scale_down(7, demand_ct=4) is True  # 7 > 4+2
+            assert tracker.should_scale_down(6, demand_ct=4) is False  # 6 <= 4+2
 
     def test_scaledown_reserve_zero_default(self):
         """With default scaledown_reserve=0, behavior matches existing tests."""
@@ -165,7 +165,7 @@ class TestFillAndScaleDown:
         assert tracker.scaledown_reserve == 0
         base = 1000.0
         with patch('time.monotonic', return_value=base):
-            tracker.fill_unknown_usage(worker_ct=3, running_ct=0)
+            tracker.fill_unknown_usage(worker_ct=3, demand_ct=0)
         with patch('time.monotonic', return_value=base + 11.0):
             assert tracker.should_scale_down(3) is True
 
@@ -176,14 +176,14 @@ class TestFillAndScaleDown:
         base = 1000.0
         # Pool was at 5 workers, all busy
         with patch('time.monotonic', return_value=base):
-            tracker.fill_unknown_usage(worker_ct=5, running_ct=5)
+            tracker.fill_unknown_usage(worker_ct=5, demand_ct=5)
         # All 5 keys blocked
         for k in range(1, 6):
             assert tracker.should_scale_down(k) is False
 
         # Pool scaled down to 2 workers, none busy
         with patch('time.monotonic', return_value=base + 1.0):
-            tracker.fill_unknown_usage(worker_ct=2, running_ct=0)
+            tracker.fill_unknown_usage(worker_ct=2, demand_ct=0)
         # Keys 3-5 were above worker_ct and stale blocked, now timestamps
         with patch('time.monotonic', return_value=base + 1.0):
             for k in range(3, 6):
@@ -201,11 +201,11 @@ class TestStatusData:
             assert v == "absent"
 
     def test_mixed_entries(self):
-        """Fill with running_ct=3 to get a mix of blocked and timestamp entries."""
+        """Fill with demand_ct=3 to get a mix of blocked and timestamp entries."""
         tracker = WorkerUsageTracker(scaledown_wait=15.0)
         base = 1000.0
         with patch('time.monotonic', return_value=base):
-            tracker.fill_unknown_usage(worker_ct=6, running_ct=3)
+            tracker.fill_unknown_usage(worker_ct=6, demand_ct=3)
 
         with patch('time.monotonic', return_value=base + 100.0):
             data = tracker.get_status_data(worker_ct=4)
@@ -229,7 +229,7 @@ class TestStatusData:
 
     def test_near_worker_ct_absent_keys(self):
         tracker = WorkerUsageTracker(scaledown_wait=15.0)
-        tracker.fill_unknown_usage(worker_ct=2, running_ct=0)
+        tracker.fill_unknown_usage(worker_ct=2, demand_ct=0)
         data = tracker.get_status_data(worker_ct=8)
         near = data["near_worker_ct"]
         assert set(near.keys()) == {6, 7, 8, 9, 10}
@@ -238,6 +238,6 @@ class TestStatusData:
 
     def test_top5_returns_highest_keys(self):
         tracker = WorkerUsageTracker(scaledown_wait=15.0)
-        tracker.fill_unknown_usage(worker_ct=8, running_ct=0)
+        tracker.fill_unknown_usage(worker_ct=8, demand_ct=0)
         data = tracker.get_status_data(worker_ct=5)
         assert set(data["top5"].keys()) == {4, 5, 6, 7, 8}

--- a/tests/unit/service/test_usage_tracker.py
+++ b/tests/unit/service/test_usage_tracker.py
@@ -135,6 +135,26 @@ class TestFillAndScaleDown:
         assert tracker.should_scale_down(2) is False
         assert tracker.should_scale_down(3) is True
 
+    def test_stale_blocked_entries_above_worker_ct_downgraded(self):
+        """Keys above worker_ct left over from a previously higher worker count
+        should be downgraded from blocked to a timestamp so they age out."""
+        tracker = WorkerUsageTracker(scaledown_wait=10.0)
+        base = 1000.0
+        # Pool was at 5 workers, all busy
+        with patch('time.monotonic', return_value=base):
+            tracker.fill_unknown_usage(worker_ct=5, running_ct=5)
+        # All 5 keys blocked
+        for k in range(1, 6):
+            assert tracker.should_scale_down(k) is False
+
+        # Pool scaled down to 2 workers, none busy
+        with patch('time.monotonic', return_value=base + 1.0):
+            tracker.fill_unknown_usage(worker_ct=2, running_ct=0)
+        # Keys 3-5 were above worker_ct and stale blocked, now timestamps
+        with patch('time.monotonic', return_value=base + 1.0):
+            for k in range(3, 6):
+                assert tracker._last_used_by_ct[k] is not tracker._SCALE_DOWN_BLOCKED
+
 
 class TestStatusData:
     def test_empty_tracker(self):

--- a/tests/unit/service/test_usage_tracker.py
+++ b/tests/unit/service/test_usage_tracker.py
@@ -5,6 +5,52 @@ from unittest.mock import patch
 from dispatcherd.service.pool import WorkerUsageTracker
 
 
+class TestRecordTaskFinish:
+    def test_recent_finish_blocks_scale_down(self):
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        tracker.record_task_finish(3)
+        assert tracker.should_scale_down(3) is False
+
+    def test_old_finish_allows_scale_down(self):
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        base = 1000.0
+        with patch('time.monotonic', return_value=base):
+            tracker.record_task_finish(3)
+        with patch('time.monotonic', return_value=base + 120.0):
+            assert tracker.should_scale_down(3) is True
+
+    def test_finish_overwrites_blocked_entry(self):
+        """record_task_finish replaces a blocked sentinel with a timestamp."""
+        tracker = WorkerUsageTracker(scaledown_wait=10.0)
+        tracker.fill_unknown_usage(worker_ct=3, running_ct=3)
+        assert tracker.should_scale_down(3) is False
+        # Task finishes — replaces blocked with timestamp
+        base = 1000.0
+        with patch('time.monotonic', return_value=base):
+            tracker.record_task_finish(3)
+        # Still blocked by recency
+        with patch('time.monotonic', return_value=base):
+            assert tracker.should_scale_down(3) is False
+        # After scaledown_wait
+        with patch('time.monotonic', return_value=base + 11.0):
+            assert tracker.should_scale_down(3) is True
+
+    def test_finish_enables_earlier_scale_down_than_periodic_fill(self):
+        """record_task_finish sets the timestamp immediately, so scale-down
+        can happen sooner than waiting for the next periodic fill."""
+        tracker = WorkerUsageTracker(scaledown_wait=10.0)
+        base = 1000.0
+        # Task finishes at time=base, setting timestamp for key 5
+        with patch('time.monotonic', return_value=base):
+            tracker.record_task_finish(5)
+        # Periodic fill at base+5 — should NOT overwrite the older timestamp
+        with patch('time.monotonic', return_value=base + 5.0):
+            tracker.fill_unknown_usage(worker_ct=5, running_ct=0)
+        # At base+11, the record_task_finish timestamp is old enough
+        with patch('time.monotonic', return_value=base + 11.0):
+            assert tracker.should_scale_down(5) is True
+
+
 class TestFillAndScaleDown:
     def test_absent_key_allows_scale_down(self):
         tracker = WorkerUsageTracker(scaledown_wait=15.0)

--- a/tests/unit/service/test_usage_tracker.py
+++ b/tests/unit/service/test_usage_tracker.py
@@ -1,0 +1,117 @@
+# Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+# See also: asyncio_tests/unit/service/test_pool_scaledown.py for async integration tests
+from unittest.mock import patch
+
+from dispatcherd.service.pool import WorkerUsageTracker
+
+
+class TestRecordAndScaleDown:
+    def test_absent_key_allows_scale_down(self):
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        assert tracker.should_scale_down(5) is True
+
+    def test_task_start_blocks_scale_down(self):
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        tracker.record_task_start(3)
+        assert tracker.should_scale_down(3) is False
+
+    def test_task_finish_recent_blocks_scale_down(self):
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        tracker.record_task_finish(3)
+        assert tracker.should_scale_down(3) is False
+
+    def test_task_finish_old_allows_scale_down(self):
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        base = 1000.0
+        with patch('time.monotonic', return_value=base):
+            tracker.record_task_finish(3)
+        with patch('time.monotonic', return_value=base + 120.0):
+            assert tracker.should_scale_down(3) is True
+
+    def test_scaledown_wait_boundary(self):
+        tracker = WorkerUsageTracker(scaledown_wait=10.0)
+        base = 1000.0
+        with patch('time.monotonic', return_value=base):
+            tracker.record_task_finish(3)
+        # Just under the wait threshold — should block
+        with patch('time.monotonic', return_value=base + 9.0):
+            assert tracker.should_scale_down(3) is False
+        # Just over the wait threshold — should allow
+        with patch('time.monotonic', return_value=base + 11.0):
+            assert tracker.should_scale_down(3) is True
+
+    def test_start_then_finish_transitions(self):
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        tracker.record_task_start(3)
+        assert tracker.should_scale_down(3) is False
+        # Finish replaces sentinel with fresh timestamp, still blocks due to recency
+        tracker.record_task_finish(3)
+        assert tracker.should_scale_down(3) is False
+
+    def test_different_worker_counts_independent(self):
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        tracker.record_task_start(2)
+        assert tracker.should_scale_down(2) is False
+        assert tracker.should_scale_down(3) is True
+
+
+class TestStatusData:
+    def test_empty_tracker(self):
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        data = tracker.get_status_data(worker_ct=3)
+        assert data["count"] == 0
+        assert data["top5"] == {}
+        assert set(data["near_worker_ct"].keys()) == {1, 2, 3, 4, 5}
+        for v in data["near_worker_ct"].values():
+            assert v == "absent"
+
+    def test_mixed_entries(self):
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        base = 1000.0
+        with patch('time.monotonic', return_value=base):
+            tracker.record_task_finish(1)
+        with patch('time.monotonic', return_value=base + 50.0):
+            tracker.record_task_finish(2)
+        tracker.record_task_start(3)
+        with patch('time.monotonic', return_value=base + 90.0):
+            tracker.record_task_finish(4)
+        tracker.record_task_start(5)
+        with patch('time.monotonic', return_value=base + 99.0):
+            tracker.record_task_finish(6)
+
+        with patch('time.monotonic', return_value=base + 100.0):
+            data = tracker.get_status_data(worker_ct=4)
+
+        assert data["count"] == 6
+        # Top 5 highest keys: 6, 5, 4, 3, 2
+        assert set(data["top5"].keys()) == {2, 3, 4, 5, 6}
+        assert data["top5"][3] == "blocked"
+        assert data["top5"][5] == "blocked"
+        assert isinstance(data["top5"][2], float)
+        assert isinstance(data["top5"][4], float)
+        assert isinstance(data["top5"][6], float)
+        # Near worker_ct=4: keys [2..6]
+        near = data["near_worker_ct"]
+        assert set(near.keys()) == {2, 3, 4, 5, 6}
+        assert isinstance(near[2], float)
+        assert near[3] == "blocked"
+        assert isinstance(near[4], float)
+        assert near[5] == "blocked"
+        assert isinstance(near[6], float)
+
+    def test_near_worker_ct_absent_keys(self):
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        tracker.record_task_finish(1)
+        tracker.record_task_finish(2)
+        data = tracker.get_status_data(worker_ct=8)
+        near = data["near_worker_ct"]
+        assert set(near.keys()) == {6, 7, 8, 9, 10}
+        for v in near.values():
+            assert v == "absent"
+
+    def test_top5_returns_highest_keys(self):
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        for i in range(1, 9):
+            tracker.record_task_finish(i)
+        data = tracker.get_status_data(worker_ct=5)
+        assert set(data["top5"].keys()) == {4, 5, 6, 7, 8}

--- a/tests/unit/service/test_usage_tracker.py
+++ b/tests/unit/service/test_usage_tracker.py
@@ -55,6 +55,62 @@ class TestRecordAndScaleDown:
         assert tracker.should_scale_down(3) is True
 
 
+class TestFillUnknownUsage:
+    def test_gaps_below_running_ct_filled_as_blocked(self):
+        """Missing keys at or below the current load are filled as blocked."""
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        tracker.record_task_start(1)
+        tracker.record_task_start(3)
+        # Key 2 is a gap — fill with running_ct=3
+        tracker.fill_unknown_usage(worker_ct=3, running_ct=3)
+        assert tracker.should_scale_down(2) is False  # filled as blocked
+
+    def test_gaps_above_running_ct_filled_as_idle(self):
+        """Missing keys above the current load are filled with a timestamp."""
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        tracker.record_task_start(1)
+        # Keys 2-5 are absent — fill with running_ct=1
+        tracker.fill_unknown_usage(worker_ct=5, running_ct=1)
+        # Keys 2-5 were filled as idle (timestamp = now), too recent to scale down
+        assert tracker.should_scale_down(2) is False
+        assert tracker.should_scale_down(5) is False
+
+    def test_does_not_overwrite_existing_entries(self):
+        """Existing entries are preserved during fill."""
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        tracker.record_task_start(2)
+        base = 1000.0
+        with patch('time.monotonic', return_value=base):
+            tracker.record_task_finish(3)
+        # Fill — key 2 (blocked) and key 3 (timestamp) should be unchanged
+        with patch('time.monotonic', return_value=base + 120.0):
+            tracker.fill_unknown_usage(worker_ct=5, running_ct=1)
+        assert tracker.should_scale_down(2) is False  # still blocked
+        with patch('time.monotonic', return_value=base + 120.0):
+            assert tracker.should_scale_down(3) is True  # still old timestamp
+
+    def test_filled_idle_entries_allow_eventual_scale_down(self):
+        """Idle-filled entries allow scale-down after scaledown_wait passes."""
+        tracker = WorkerUsageTracker(scaledown_wait=10.0)
+        base = 1000.0
+        with patch('time.monotonic', return_value=base):
+            tracker.fill_unknown_usage(worker_ct=3, running_ct=0)
+        # Immediately after fill — too recent
+        with patch('time.monotonic', return_value=base):
+            assert tracker.should_scale_down(1) is False
+        # After scaledown_wait — allowed
+        with patch('time.monotonic', return_value=base + 11.0):
+            assert tracker.should_scale_down(1) is True
+            assert tracker.should_scale_down(2) is True
+            assert tracker.should_scale_down(3) is True
+
+    def test_is_tracked(self):
+        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+        assert tracker.is_tracked(3) is False
+        tracker.record_task_start(3)
+        assert tracker.is_tracked(3) is True
+
+
 class TestStatusData:
     def test_empty_tracker(self):
         tracker = WorkerUsageTracker(scaledown_wait=15.0)

--- a/tests/unit/service/test_usage_tracker.py
+++ b/tests/unit/service/test_usage_tracker.py
@@ -5,34 +5,33 @@ from unittest.mock import patch
 from dispatcherd.service.pool import WorkerUsageTracker
 
 
-class TestRecordAndScaleDown:
+class TestFillAndScaleDown:
     def test_absent_key_allows_scale_down(self):
         tracker = WorkerUsageTracker(scaledown_wait=15.0)
         assert tracker.should_scale_down(5) is True
 
-    def test_task_start_blocks_scale_down(self):
+    def test_active_load_blocks_scale_down(self):
+        """Keys at or below running_ct are blocked."""
         tracker = WorkerUsageTracker(scaledown_wait=15.0)
-        tracker.record_task_start(3)
+        tracker.fill_unknown_usage(worker_ct=3, running_ct=3)
         assert tracker.should_scale_down(3) is False
 
-    def test_task_finish_recent_blocks_scale_down(self):
-        tracker = WorkerUsageTracker(scaledown_wait=15.0)
-        tracker.record_task_finish(3)
-        assert tracker.should_scale_down(3) is False
-
-    def test_task_finish_old_allows_scale_down(self):
-        tracker = WorkerUsageTracker(scaledown_wait=15.0)
+    def test_idle_surplus_blocks_until_scaledown_wait(self):
+        """Keys above running_ct get a fresh timestamp — blocked until scaledown_wait passes."""
+        tracker = WorkerUsageTracker(scaledown_wait=10.0)
         base = 1000.0
         with patch('time.monotonic', return_value=base):
-            tracker.record_task_finish(3)
-        with patch('time.monotonic', return_value=base + 120.0):
+            tracker.fill_unknown_usage(worker_ct=3, running_ct=0)
+        with patch('time.monotonic', return_value=base):
+            assert tracker.should_scale_down(3) is False
+        with patch('time.monotonic', return_value=base + 11.0):
             assert tracker.should_scale_down(3) is True
 
     def test_scaledown_wait_boundary(self):
         tracker = WorkerUsageTracker(scaledown_wait=10.0)
         base = 1000.0
         with patch('time.monotonic', return_value=base):
-            tracker.record_task_finish(3)
+            tracker.fill_unknown_usage(worker_ct=3, running_ct=0)
         # Just under the wait threshold — should block
         with patch('time.monotonic', return_value=base + 9.0):
             assert tracker.should_scale_down(3) is False
@@ -40,75 +39,55 @@ class TestRecordAndScaleDown:
         with patch('time.monotonic', return_value=base + 11.0):
             assert tracker.should_scale_down(3) is True
 
-    def test_start_then_finish_transitions(self):
+    def test_blocked_entries_refresh_when_still_active(self):
+        """Repeated fills with same running_ct keep entries blocked."""
         tracker = WorkerUsageTracker(scaledown_wait=15.0)
-        tracker.record_task_start(3)
-        assert tracker.should_scale_down(3) is False
-        # Finish replaces sentinel with fresh timestamp, still blocks due to recency
-        tracker.record_task_finish(3)
-        assert tracker.should_scale_down(3) is False
-
-    def test_different_worker_counts_independent(self):
-        tracker = WorkerUsageTracker(scaledown_wait=15.0)
-        tracker.record_task_start(2)
-        assert tracker.should_scale_down(2) is False
-        assert tracker.should_scale_down(3) is True
-
-
-class TestFillUnknownUsage:
-    def test_gaps_below_running_ct_filled_as_blocked(self):
-        """Missing keys at or below the current load are filled as blocked."""
-        tracker = WorkerUsageTracker(scaledown_wait=15.0)
-        tracker.record_task_start(1)
-        tracker.record_task_start(3)
-        # Key 2 is a gap — fill with running_ct=3
         tracker.fill_unknown_usage(worker_ct=3, running_ct=3)
-        assert tracker.should_scale_down(2) is False  # filled as blocked
+        assert tracker.should_scale_down(3) is False
+        # Second fill, still loaded
+        tracker.fill_unknown_usage(worker_ct=3, running_ct=3)
+        assert tracker.should_scale_down(3) is False
 
-    def test_gaps_above_running_ct_filled_as_idle(self):
-        """Missing keys above the current load are filled with a timestamp."""
-        tracker = WorkerUsageTracker(scaledown_wait=15.0)
-        tracker.record_task_start(1)
-        # Keys 2-5 are absent — fill with running_ct=1
-        tracker.fill_unknown_usage(worker_ct=5, running_ct=1)
-        # Keys 2-5 were filled as idle (timestamp = now), too recent to scale down
-        assert tracker.should_scale_down(2) is False
-        assert tracker.should_scale_down(5) is False
-
-    def test_does_not_overwrite_existing_entries(self):
-        """Existing entries are preserved during fill."""
-        tracker = WorkerUsageTracker(scaledown_wait=15.0)
-        tracker.record_task_start(2)
+    def test_blocked_entries_convert_to_timestamp_when_idle(self):
+        """When running_ct drops, previously blocked entries above it
+        are replaced with a timestamp and start aging."""
+        tracker = WorkerUsageTracker(scaledown_wait=10.0)
         base = 1000.0
-        with patch('time.monotonic', return_value=base):
-            tracker.record_task_finish(3)
-        # Fill — key 2 (blocked) and key 3 (timestamp) should be unchanged
-        with patch('time.monotonic', return_value=base + 120.0):
-            tracker.fill_unknown_usage(worker_ct=5, running_ct=1)
-        assert tracker.should_scale_down(2) is False  # still blocked
-        with patch('time.monotonic', return_value=base + 120.0):
-            assert tracker.should_scale_down(3) is True  # still old timestamp
+        # First fill: all 3 keys blocked
+        tracker.fill_unknown_usage(worker_ct=3, running_ct=3)
+        assert tracker.should_scale_down(3) is False
 
-    def test_filled_idle_entries_allow_eventual_scale_down(self):
-        """Idle-filled entries allow scale-down after scaledown_wait passes."""
+        # Second fill: running_ct dropped, key 3 was blocked but now idle
+        with patch('time.monotonic', return_value=base):
+            tracker.fill_unknown_usage(worker_ct=3, running_ct=1)
+        # Key 3 now has a timestamp, but too recent
+        with patch('time.monotonic', return_value=base):
+            assert tracker.should_scale_down(3) is False
+        # After scaledown_wait, key 3 allows scale-down
+        with patch('time.monotonic', return_value=base + 11.0):
+            assert tracker.should_scale_down(3) is True
+        # Key 1 is still blocked (at running_ct)
+        with patch('time.monotonic', return_value=base + 11.0):
+            assert tracker.should_scale_down(1) is False
+
+    def test_existing_timestamps_not_overwritten_by_fill(self):
+        """Timestamps above running_ct are preserved so they keep aging."""
         tracker = WorkerUsageTracker(scaledown_wait=10.0)
         base = 1000.0
         with patch('time.monotonic', return_value=base):
             tracker.fill_unknown_usage(worker_ct=3, running_ct=0)
-        # Immediately after fill — too recent
-        with patch('time.monotonic', return_value=base):
-            assert tracker.should_scale_down(1) is False
-        # After scaledown_wait — allowed
+        # Second fill much later — timestamps should NOT be refreshed
+        with patch('time.monotonic', return_value=base + 100.0):
+            tracker.fill_unknown_usage(worker_ct=3, running_ct=0)
+        # Original timestamps are preserved, so they're old enough
         with patch('time.monotonic', return_value=base + 11.0):
-            assert tracker.should_scale_down(1) is True
-            assert tracker.should_scale_down(2) is True
             assert tracker.should_scale_down(3) is True
 
-    def test_is_tracked(self):
+    def test_different_worker_counts_independent(self):
         tracker = WorkerUsageTracker(scaledown_wait=15.0)
-        assert tracker.is_tracked(3) is False
-        tracker.record_task_start(3)
-        assert tracker.is_tracked(3) is True
+        tracker.fill_unknown_usage(worker_ct=2, running_ct=2)
+        assert tracker.should_scale_down(2) is False
+        assert tracker.should_scale_down(3) is True
 
 
 class TestStatusData:
@@ -122,18 +101,11 @@ class TestStatusData:
             assert v == "absent"
 
     def test_mixed_entries(self):
+        """Fill with running_ct=3 to get a mix of blocked and timestamp entries."""
         tracker = WorkerUsageTracker(scaledown_wait=15.0)
         base = 1000.0
         with patch('time.monotonic', return_value=base):
-            tracker.record_task_finish(1)
-        with patch('time.monotonic', return_value=base + 50.0):
-            tracker.record_task_finish(2)
-        tracker.record_task_start(3)
-        with patch('time.monotonic', return_value=base + 90.0):
-            tracker.record_task_finish(4)
-        tracker.record_task_start(5)
-        with patch('time.monotonic', return_value=base + 99.0):
-            tracker.record_task_finish(6)
+            tracker.fill_unknown_usage(worker_ct=6, running_ct=3)
 
         with patch('time.monotonic', return_value=base + 100.0):
             data = tracker.get_status_data(worker_ct=4)
@@ -141,24 +113,23 @@ class TestStatusData:
         assert data["count"] == 6
         # Top 5 highest keys: 6, 5, 4, 3, 2
         assert set(data["top5"].keys()) == {2, 3, 4, 5, 6}
+        assert data["top5"][2] == "blocked"
         assert data["top5"][3] == "blocked"
-        assert data["top5"][5] == "blocked"
-        assert isinstance(data["top5"][2], float)
         assert isinstance(data["top5"][4], float)
+        assert isinstance(data["top5"][5], float)
         assert isinstance(data["top5"][6], float)
         # Near worker_ct=4: keys [2..6]
         near = data["near_worker_ct"]
         assert set(near.keys()) == {2, 3, 4, 5, 6}
-        assert isinstance(near[2], float)
+        assert near[2] == "blocked"
         assert near[3] == "blocked"
         assert isinstance(near[4], float)
-        assert near[5] == "blocked"
+        assert isinstance(near[5], float)
         assert isinstance(near[6], float)
 
     def test_near_worker_ct_absent_keys(self):
         tracker = WorkerUsageTracker(scaledown_wait=15.0)
-        tracker.record_task_finish(1)
-        tracker.record_task_finish(2)
+        tracker.fill_unknown_usage(worker_ct=2, running_ct=0)
         data = tracker.get_status_data(worker_ct=8)
         near = data["near_worker_ct"]
         assert set(near.keys()) == {6, 7, 8, 9, 10}
@@ -167,7 +138,6 @@ class TestStatusData:
 
     def test_top5_returns_highest_keys(self):
         tracker = WorkerUsageTracker(scaledown_wait=15.0)
-        for i in range(1, 9):
-            tracker.record_task_finish(i)
+        tracker.fill_unknown_usage(worker_ct=8, running_ct=0)
         data = tracker.get_status_data(worker_ct=5)
         assert set(data["top5"].keys()) == {4, 5, 6, 7, 8}


### PR DESCRIPTION
We saw excessive memory use, and this seems to be caused by a race condition where we get a lot of tasks, and some tasks finish while we're still in the code path of dispatching other tasks. This leaves the dangerous internal data structure of last-used-by-counts filled to an unexpected worker count, and the method conflated a discovered `None` value with that meaning that we _need_ that many workers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core worker auto-scaling/retirement logic and introduces new state tracking under concurrency; mistakes could cause over/under-scaling or delayed worker retirement. Added tests and lock-scoped updates mitigate risk, but behavior changes are significant in production workload patterns.
> 
> **Overview**
> Fixes scale-down race/incorrectness by replacing `last_used_by_ct` with a demand-aware `WorkerUsageTracker` that distinguishes *blocked* (at/below demand) from idle timestamps, updates on task completion (`record_task_finish`), and provides debug summaries in `get_status_data()`.
> 
> Updates `WorkerPool.scale_workers()` to retire surplus workers in a loop (down to `min_workers` and `demand + scaledown_reserve`), capped at 300 stops per tick, and adds new `scaledown_reserve` configuration to `schema.json`.
> 
> Adds extensive new tests for scaledown behavior and diagnostics, plus a fake pool/process manager test harness to avoid real multiprocessing where not needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 949edaf5a43aaab4be6ee184f56b244596a27460. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->