### PR TITLE
feat: enforce uuid4 format and add origin field to message data

### DIFF
--- a/asyncio_tests/integration/test_disruptions.py
+++ b/asyncio_tests/integration/test_disruptions.py
@@ -76,7 +76,7 @@ async def test_task_breaks_connection(apg_dispatcher, test_settings, caplog):
     clearing_task = asyncio.create_task(apg_dispatcher.pool.events.work_cleared.wait())
     caplog.clear()
     with caplog.at_level("DEBUG"):
-        do_database_query.apply_async(settings=test_settings, uuid='sanity')
+        do_database_query.apply_async(settings=test_settings, uuid='a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d')
         await asyncio.wait_for(clearing_task, timeout=3)
 
     assert "Worker 0 finished task" in caplog.text
@@ -94,8 +94,8 @@ async def test_task_breaks_connection(apg_dispatcher, test_settings, caplog):
     clearing_task = asyncio.create_task(apg_dispatcher.pool.events.work_cleared.wait())
     caplog.clear()
     with caplog.at_level("DEBUG"):
-        do_database_query.apply_async(settings=test_settings, uuid='real_test')
+        do_database_query.apply_async(settings=test_settings, uuid='b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e')
         await asyncio.wait_for(clearing_task, timeout=3)
 
-    assert "Worker 0 finished task (uuid=real_test)" in caplog.text
+    assert "Worker 0 finished task (uuid=b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e)" in caplog.text
     assert apg_dispatcher.pool.finished_count == 3

--- a/asyncio_tests/integration/test_signal_handling.py
+++ b/asyncio_tests/integration/test_signal_handling.py
@@ -32,7 +32,7 @@ async def test_sigusr1_cancel_avoids_sigterm(apg_dispatcher, pg_control, test_se
     """
 
     # Submit the task
-    uuid_val = "test-sigusr1-cancel-inline"
+    uuid_val = "c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f"
     sigterm_interceptor_task.apply_async(uuid=uuid_val, settings=test_settings)
 
     # Give the dispatcher a moment to start the task

--- a/dispatcherd/publish.py
+++ b/dispatcherd/publish.py
@@ -122,6 +122,7 @@ def submit_task(
     args: Optional[tuple] = None,
     kwargs: Optional[dict] = None,
     uuid: Optional[str] = None,
+    origin: Optional[str] = None,
     queue: Optional[str] = None,
     timeout: Optional[float] = 0.0,
     processor_options: Iterable[ProcessorParams] = (),
@@ -163,5 +164,5 @@ def submit_task(
         dmethod = DispatcherMethod(fn)
 
     return dmethod.apply_async(
-        args=args, kwargs=kwargs, queue=queue, uuid=uuid, bind=bind, settings=settings, timeout=timeout, processor_options=processor_options
+        args=args, kwargs=kwargs, queue=queue, uuid=uuid, origin=origin, bind=bind, settings=settings, timeout=timeout, processor_options=processor_options
     )

--- a/dispatcherd/registry.py
+++ b/dispatcherd/registry.py
@@ -1,6 +1,5 @@
 import inspect
 import json
-import logging
 import threading
 import time
 from typing import Callable, Iterable, Optional, Set, Tuple
@@ -10,8 +9,6 @@ from .config import LazySettings
 from .config import settings as global_settings
 from .protocols import ProcessorParams
 from .utils import MODULE_METHOD_DELIMITER, DispatcherCallable, resolve_callable
-
-logger = logging.getLogger(__name__)
 
 
 class DispatcherError(RuntimeError):
@@ -105,8 +102,7 @@ class DispatcherMethod:
                 if str(val) != uuid:
                     raise ValueError
             except (ValueError, TypeError, AttributeError):
-                logger.warning(f"Invalid UUID4 format provided: {uuid}. Replacing with self-generated UUID4.")
-                uuid = str(uuid4())
+                raise ValueError(f"Invalid UUID4 format provided: {uuid!r}. Caller must supply a valid uuid4 string.")
         else:
             uuid = str(uuid4())
 

--- a/dispatcherd/registry.py
+++ b/dispatcherd/registry.py
@@ -4,7 +4,7 @@ import logging
 import threading
 import time
 from typing import Callable, Iterable, Optional, Set, Tuple
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from .config import LazySettings
 from .config import settings as global_settings
@@ -87,6 +87,7 @@ class DispatcherMethod:
         args: Optional[tuple] = None,
         kwargs: Optional[dict] = None,
         uuid: Optional[str] = None,
+        origin: Optional[str] = None,
         bind: bool = False,
         timeout: Optional[float] = 0.0,
         processor_options: Iterable[ProcessorParams] = (),
@@ -97,8 +98,22 @@ class DispatcherMethod:
         If a task is submitted to a multiprocessing pool, skipping pg_notify, this might be used directly
         """
         body = self.publication_defaults()
-        # These params are forced to be set on every submission, can not be generic to task
-        body['uuid'] = uuid or str(uuid4())
+
+        if uuid:
+            try:
+                val = UUID(uuid, version=4)
+                if str(val) != uuid:
+                    raise ValueError
+            except (ValueError, TypeError, AttributeError):
+                logger.warning(f"Invalid UUID4 format provided: {uuid}. Replacing with self-generated UUID4.")
+                uuid = str(uuid4())
+        else:
+            uuid = str(uuid4())
+
+        body['uuid'] = uuid
+
+        if origin:
+            body['origin'] = origin
 
         if args:
             body['args'] = args
@@ -122,6 +137,7 @@ class DispatcherMethod:
         kwargs: Optional[dict] = None,
         queue: str | Callable[..., str] | None = None,
         uuid: Optional[str] = None,
+        origin: Optional[str] = None,
         settings: LazySettings = global_settings,
         bind: bool = False,
         timeout: Optional[float] = 0.0,
@@ -139,7 +155,9 @@ class DispatcherMethod:
         else:
             resolved_queue = queue  # Can still be None if we rely on the broker default channel
 
-        obj = self.get_async_body(args=args, kwargs=kwargs, uuid=uuid, bind=bind, timeout=timeout, processor_options=processor_options)
+        obj = self.get_async_body(
+            args=args, kwargs=kwargs, uuid=uuid, origin=origin, bind=bind, timeout=timeout, processor_options=processor_options
+        )
 
         from dispatcherd.factories import get_publisher_from_settings
 


### PR DESCRIPTION
Fixes #96. This PR adds validation to ensure that all message UUIDs are in valid UUID4 format, and introduces an 'origin' field to help identify the source of messages.