### PR TITLE
Fix apply_async to fall back to task-configured queue when none specified

### DIFF
--- a/dispatcherd/registry.py
+++ b/dispatcherd/registry.py
@@ -80,7 +80,7 @@ class DispatcherMethod:
         return defaults
 
     def delay(self, *args, **kwargs) -> Tuple[dict, str]:
-        return self.apply_async(args=args, kwargs=kwargs)
+        return self.apply_async(args=args, kwargs=kwargs, queue=self.queue)
 
     def get_async_body(
         self,

--- a/dispatcherd/registry.py
+++ b/dispatcherd/registry.py
@@ -80,7 +80,7 @@ class DispatcherMethod:
         return defaults
 
     def delay(self, *args, **kwargs) -> Tuple[dict, str]:
-        return self.apply_async(args=args, kwargs=kwargs, queue=self.queue)
+        return self.apply_async(args=args, kwargs=kwargs)
 
     def get_async_body(
         self,
@@ -134,10 +134,11 @@ class DispatcherMethod:
         """
 
         resolved_queue: Optional[str]
-        if queue and callable(queue):
-            resolved_queue = queue()
+        effective_queue = queue if queue is not None else self.queue
+        if effective_queue and callable(effective_queue):
+            resolved_queue = effective_queue()
         else:
-            resolved_queue = queue  # Can still be None if we rely on the broker default channel
+            resolved_queue = effective_queue  # Can still be None if we rely on the broker default channel
 
         obj = self.get_async_body(args=args, kwargs=kwargs, uuid=uuid, bind=bind, timeout=timeout, processor_options=processor_options)
 

--- a/tests/integration/publish/test_registry.py
+++ b/tests/integration/publish/test_registry.py
@@ -26,3 +26,35 @@ def test_apply_async_with_no_queue(registry, conn_config):
         mock_publish_method.assert_called_once_with(channel='fooqueue', message=mock.ANY)
 
     mock_publish_method.assert_called_once()
+
+
+def test_delay_uses_task_queue(registry, conn_config):
+    """Task decorated with queue= should publish to that queue when using .delay()"""
+
+    @task(queue='task_specific_queue', registry=registry)
+    def test_method():
+        return
+
+    dmethod = registry.get_from_callable(test_method)
+
+    with temporary_settings({'version': 2, 'brokers': {'pg_notify': {'config': conn_config}}}):
+        with mock.patch('dispatcherd.brokers.pg_notify.Broker.publish_message') as mock_publish_method:
+            dmethod.delay()
+
+        mock_publish_method.assert_called_once_with(channel='task_specific_queue', message=mock.ANY)
+
+
+def test_apply_async_explicit_queue_overrides_task_queue(registry, conn_config):
+    """Explicit queue in apply_async() should override the task's decorated queue"""
+
+    @task(queue='task_specific_queue', registry=registry)
+    def test_method():
+        return
+
+    dmethod = registry.get_from_callable(test_method)
+
+    with temporary_settings({'version': 2, 'brokers': {'pg_notify': {'config': conn_config}}}):
+        with mock.patch('dispatcherd.brokers.pg_notify.Broker.publish_message') as mock_publish_method:
+            dmethod.apply_async(queue='override_queue')
+
+        mock_publish_method.assert_called_once_with(channel='override_queue', message=mock.ANY)

--- a/tests/unit/test_publish.py
+++ b/tests/unit/test_publish.py
@@ -20,7 +20,7 @@ def test_method_normal_call(registry, mock_apply_async):
 
     test_method.delay()
 
-    mock_apply_async.assert_called_once_with(args=(), kwargs={})
+    mock_apply_async.assert_called_once_with(args=(), kwargs={}, queue=None)
 
 
 def test_method_call_with_args_kwargs(registry, mock_apply_async):
@@ -31,7 +31,7 @@ def test_method_call_with_args_kwargs(registry, mock_apply_async):
 
     test_method.delay(1, 2, 3, foo=6, bar=7)
 
-    mock_apply_async.assert_called_once_with(args=(1, 2, 3), kwargs={"foo": 6, "bar": 7})
+    mock_apply_async.assert_called_once_with(args=(1, 2, 3), kwargs={"foo": 6, "bar": 7}, queue=None)
 
 
 def test_method_call_with_options(registry, mock_apply_async):
@@ -52,7 +52,7 @@ def test_using_as_decorator(registry, mock_apply_async):
 
     test_method.delay()
 
-    mock_apply_async.assert_called_once_with(args=(), kwargs={})
+    mock_apply_async.assert_called_once_with(args=(), kwargs={}, queue=None)
 
 
 def test_decorator_kwargs(registry):
@@ -75,7 +75,7 @@ def test_class_normal_call(registry, mock_apply_async):
 
     TestMethod.delay()
 
-    mock_apply_async.assert_called_once_with(args=(), kwargs={})
+    mock_apply_async.assert_called_once_with(args=(), kwargs={}, queue=None)
 
 
 def test_submit_task_method(registry, mock_apply_async, test_settings):

--- a/tests/unit/test_publish.py
+++ b/tests/unit/test_publish.py
@@ -20,7 +20,7 @@ def test_method_normal_call(registry, mock_apply_async):
 
     test_method.delay()
 
-    mock_apply_async.assert_called_once_with(args=(), kwargs={}, queue=None)
+    mock_apply_async.assert_called_once_with(args=(), kwargs={})
 
 
 def test_method_call_with_args_kwargs(registry, mock_apply_async):
@@ -31,7 +31,7 @@ def test_method_call_with_args_kwargs(registry, mock_apply_async):
 
     test_method.delay(1, 2, 3, foo=6, bar=7)
 
-    mock_apply_async.assert_called_once_with(args=(1, 2, 3), kwargs={"foo": 6, "bar": 7}, queue=None)
+    mock_apply_async.assert_called_once_with(args=(1, 2, 3), kwargs={"foo": 6, "bar": 7})
 
 
 def test_method_call_with_options(registry, mock_apply_async):
@@ -52,7 +52,7 @@ def test_using_as_decorator(registry, mock_apply_async):
 
     test_method.delay()
 
-    mock_apply_async.assert_called_once_with(args=(), kwargs={}, queue=None)
+    mock_apply_async.assert_called_once_with(args=(), kwargs={})
 
 
 def test_decorator_kwargs(registry):
@@ -75,7 +75,7 @@ def test_class_normal_call(registry, mock_apply_async):
 
     TestMethod.delay()
 
-    mock_apply_async.assert_called_once_with(args=(), kwargs={}, queue=None)
+    mock_apply_async.assert_called_once_with(args=(), kwargs={})
 
 
 def test_submit_task_method(registry, mock_apply_async, test_settings):


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AAP-69693

Tasks decorated with `queue=` had their queue ignored when dispatched via `.delay()` or `apply_async()` without an explicit `queue` argument, causing them to publish to the broker's default channel instead of the intended queue. This broke cross-pod task dispatch (e.g., web pod dispatching to task pod) when the queues differed.

## Fix

In `apply_async()`, resolve `queue` by falling back to `self.queue` when no explicit `queue` argument is provided, before resolving callable queue providers:

```python
effective_queue = queue if queue is not None else self.queue
```

This means `delay()` (which calls `apply_async` with no `queue`) now correctly uses the task's configured queue without any changes to `delay()` itself.

## Risk

Low risk, localized change to `apply_async` in `registry.py`. Main risk: callers that previously relied on the broker default channel for tasks with `self.queue` set will now route to that queue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to task publication routing; main risk is behavior change for tasks with `self.queue` set that previously went to the broker default channel.
> 
> **Overview**
> `DispatcherMethod.apply_async()` now resolves an *effective queue* by falling back to `self.queue` when the caller doesn’t pass `queue`, including when the queue is a callable, so `.delay()` correctly publishes to the task-configured channel.
> 
> Adds integration tests verifying that `.delay()` uses the decorated task queue and that an explicit `apply_async(queue=...)` overrides the task default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dad7ce0895f2511b99c28db267c1f32d62a2c93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->